### PR TITLE
ORM changes

### DIFF
--- a/modules/orm/classes/Kohana/ORM.php
+++ b/modules/orm/classes/Kohana/ORM.php
@@ -856,6 +856,10 @@ class Kohana_ORM extends Model implements serializable {
 	{
 		$value = $this->get($column);
 		
+		if ($value === NULL)
+			return NULL;
+
+		// Call __get for any user processing
 		switch($this->table_column_type($column))
 		{
 			case 'float':  return floatval($this->__get($column));
@@ -863,7 +867,7 @@ class Kohana_ORM extends Model implements serializable {
 			case 'string': return strval($this->__get($column));
 		}
 		
-		return FALSE;
+		return $value;
 	}
 
 	/**
@@ -886,12 +890,12 @@ class Kohana_ORM extends Model implements serializable {
 		}
 		else
 		{
-		foreach ($this->_object as $column => $value)
-		{
-			// Call __get for any user processing
+			foreach ($this->_object as $column => $value)
+			{
+				// Call __get for any user processing
 				if (!in_array($column, $this->_private_columns))
-			$object[$column] = $this->__get($column);
-		}
+					$object[$column] = $this->__get($column);
+			}
 		}
 
 		foreach ($this->_related as $column => $model)
@@ -926,7 +930,9 @@ class Kohana_ORM extends Model implements serializable {
 			foreach ($this->_object as $column => $value)
 			{
 				if (!in_array($column, $this->_private_columns))
+				{
 					$object->{$column} = $this->get_typed($column);
+				}
 			}
 		}
 
@@ -1445,7 +1451,7 @@ class Kohana_ORM extends Model implements serializable {
 			->values(array_values($data))
 			->execute($this->_db);
 
-		if ( ! array_key_exists($this->_primary_key, $data))
+		if ( ! array_key_exists($this->_primary_key, $data) OR ($this->_object[$this->_primary_key] === NULL))
 		{
 			// Load the insert id as the primary key if it was left out
 			$this->_object[$this->_primary_key] = $this->_primary_key_value = $result[0];
@@ -2481,5 +2487,17 @@ class Kohana_ORM extends Model implements serializable {
 		}
 
 		return ( ! $model->loaded());
+	}
+
+
+	/**
+	 * Get the quoted table name from the model name
+	 *
+	 * @param   string   $orm_model  Model name
+	 * @return  string   Quoted table name
+	 */
+	public static function quote_table($orm_model)
+	{
+		return Database::instance()->quote_table(strtolower($orm_model));
 	}
 } // End ORM

--- a/modules/orm/guide/orm/behaviors.md
+++ b/modules/orm/guide/orm/behaviors.md
@@ -1,0 +1,118 @@
+# Behaviors
+
+Behaviors allow to set and/or modify model field data by attaching the behavior to the model. A behavior can be implemented once an attached to different models, the number of behaviors that can be attached is unlimited.
+
+A good example is a slug for a page, this is based on a title and needs to be updated during the commit. This slug can then be used in the URL to retrieve the model.
+
+	public function behavior()
+	{
+		return array(
+			// Guid generation
+			// Generate a guid and store in in the guid column
+			'Guid' => array('column' => 'guid'),
+			
+			// Slug generation
+			// Generate a slug from the title column and store in in the slug column
+			'Slug' => array('source'=>'title', column' => 'slug'),
+		);
+	}
+
+## Behaviors types
+### Guid
+
+This behavior will generate a GUID and store it in the specified column.
+
+If the `column` key is ommited the '`guid`' column will be used to store the generated GUID.
+
+	public function behavior()
+	{
+		return array(
+			...
+			'Guid' => array(
+				'column'      => '[column name]'
+			),
+			...
+		);
+	}
+
+### Slug
+
+This behavior will generate a slug from the `source` field and store it in the specified column. 
+
+If the `source` key is ommited the '`name`' column will be used to create the slug. If the `column` key is ommited the '`slug`' column will be used to create the slug.
+
+	public function behavior()
+	{
+		return array(
+			...
+			'Slug' => array(
+				'source'      => '[column name]',
+				'column'      => '[column name]'
+			),
+			...
+		);
+	}
+
+### LocalBehavior
+
+Allows the creation of a local behavior that is model specific.
+The function takes up to two arguments; the first argument contains the type of operation on the model and can be either '`construct`' during construction of the model class, '`update`' when the model is updated or '`create`' when the model is created.
+
+	public function behavior()
+	{
+		return array(
+			...
+			// Callback static method
+			TRUE => array('MyClass::static_method'),
+			// Callback method
+			TRUE => array($this, 'custom_behavior')),
+			// Function as the callback (PHP 5.3+)
+			TRUE => function($action) {
+				// Do something to $value and return it.
+				return some_function($action);
+			},
+
+			...
+		);
+	}
+
+## Writing new behaviors
+
+It is possible to create custom behaviors that can be reused in different models.
+
+Create a subclass of the `ORM_Behavior` class and implement the `on_construct`, `on_update` and `on_create` functions.
+
+	class ORM_Behavior_MyBehavior extends ORM_Behavior {
+
+		/**
+		 * Constructs a new model and loads a record if given
+		 *
+		 * @param   ORM   $model The model
+		 * @param   mixed $id    Parameter for find or object to load
+		 */
+		public function on_construct($model, $id)
+		{
+			// return FALSE if the model is loaded from this function.
+			return TRUE;
+		}
+
+		/**
+		 * The model is updated
+		 *
+		 * @param   ORM   $model The model
+		 */
+		public function on_update($model)
+		{
+			// Modify or update the appropriate fields
+		}
+
+		/**
+		 * A new model is created, add a guid value
+		 *
+		 * @param   ORM   $model The model
+		 */
+		public function on_create($model)
+		{
+			// Modify or update the appropriate fields
+		}
+	}

--- a/modules/orm/guide/orm/menu.md
+++ b/modules/orm/guide/orm/menu.md
@@ -4,6 +4,7 @@
 - [Relationships](relationships)
 - [Validation](validation)
 - [Filters](filters)
+- [Behaviors](behaviors)
 - [Examples](examples)
     - [Simple](examples/simple)
     - [Validation](examples/validation)

--- a/modules/orm/guide/orm/relationships.md
+++ b/modules/orm/guide/orm/relationships.md
@@ -94,6 +94,7 @@ To define the `has_many` "through" relationship, the same syntax for standard ha
 		'categories' => array(
 			'model'   => 'Category',
 			'through' => 'categories_posts',
+			'update'  => FALSE
 		),
 	);
 
@@ -103,6 +104,7 @@ In the Category model:
 		'posts' => array(
 			'model'   => 'Post',
 			'through' => 'categories_posts',
+			'update'  => FALSE
 		),
 	);
 
@@ -121,3 +123,10 @@ Assuming you want to add the relationship (by creating a new record in the categ
 To remove:
 
 	$post->remove('categories', $category);
+
+Another option is to set the `update` parameter in the relation definition to `TRUE`.
+
+If the relation field is set all new values will be added and all removed values will be removed to the table automatically. The array should contain a list of all primary keys.
+
+	$post->set('categories', array(1, 4, 7, 23));
+


### PR DESCRIPTION
Corrected return values for `get_typed` function.
Added a (static) helper function `quote_table` that allows quoting the table of used in the model (based on the name). This is handy when writing "native" queries that use tables from models.
Function create will also load the insert id as the primary key if the primary key is NULL.
Furthermore I fixed some indents of a previous change.