### PR TITLE
Correct expected keys using ORM values method

### DIFF
--- a/modules/orm/classes/Kohana/Auth/ORM.php
+++ b/modules/orm/classes/Kohana/Auth/ORM.php
@@ -100,7 +100,7 @@ class Kohana_Auth_ORM extends Auth {
 
 				// Create a new autologin token
 				$token = ORM::factory('User_Token')
-							->values($data)
+							->values($data, array_keys($data))
 							->create();
 
 				// Set the autologin cookie


### PR DESCRIPTION
Somewhere along the line `ORM::values` got a new required argument, expected keys, but `Kohana_Auth_ORM` wasn't adapted.