### PR TITLE
#145 fix Wrong Class Name in UnitTest - PHPUnit\DbUnit required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",
+    "phpunit/dbunit":"3.*",
     "phing/phing": "^2.16"
   },
   "conflict": {

--- a/modules/unittest/classes/Kohana/Unittest/Database/TestCase.php
+++ b/modules/unittest/classes/Kohana/Unittest/Database/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+use PHPUnit\DbUnit\TestCase;
 /**
  * TestCase for testing a database
  *
@@ -8,7 +9,7 @@
  * @copyright  (c) Kohana Team
  * @license    https://koseven.ga/LICENSE.md
  */
-abstract class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Database_TestCase {
+abstract class Kohana_Unittest_Database_TestCase extends TestCase{
 
 
 	/**


### PR DESCRIPTION
Database unittest required a PHPUnit Class that has been moved.