### PR TITLE
Fix DOCROOT path which could be wrong when using CLI minion task

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -54,7 +54,7 @@ error_reporting(E_ALL | E_STRICT);
  */
 
 // Set the full path to the docroot
-define('DOCROOT', realpath('../').DIRECTORY_SEPARATOR);
+define('DOCROOT', realpath(__DIR__.'/../').DIRECTORY_SEPARATOR);
 
 // Make the application relative to the docroot, for symlink'd index.php
 if ( ! is_dir($application) AND is_dir(DOCROOT.$application))


### PR DESCRIPTION
Fix the issue opened [here](https://github.com/koseven/koseven/issues/174)

The path is wrong when running minion tasks from the root directory :
`./modules/minion/minion TaskToRun`

The path is only right when running tasks from the module directory.
It needs to be absolute and not relative to be right everywhere.