### PR TITLE
fix for #184 - Parameter must be an array or an object that implement…

### DIFF
--- a/modules/orm/classes/Kohana/ORM.php
+++ b/modules/orm/classes/Kohana/ORM.php
@@ -1640,7 +1640,7 @@ class Kohana_ORM extends Model implements serializable {
 		}
 		else
 		{
-			return $count === ((is_int($far_keys) || is_string($far_keys)) ? 1 : count($far_keys));
+			return $count === ((is_int($far_keys) || is_string($far_keys) || (is_object($far_keys))) ? 1 : count($far_keys));
 		}
 
 	}

--- a/modules/orm/classes/Kohana/ORM.php
+++ b/modules/orm/classes/Kohana/ORM.php
@@ -1640,7 +1640,7 @@ class Kohana_ORM extends Model implements serializable {
 		}
 		else
 		{
-			return $count === count($far_keys);
+			return $count === ((is_int($far_keys) || is_string($far_keys)) ? 1 : count($far_keys));
 		}
 
 	}


### PR DESCRIPTION
in PHP 7.2 count() can take only arrays and Countables as parameter. 