### PR TITLE
Update I18n.php

### DIFF
--- a/system/classes/Kohana/I18n.php
+++ b/system/classes/Kohana/I18n.php
@@ -117,7 +117,7 @@ class Kohana_I18n {
 				foreach ($files as $file)
 				{
 					// Merge the language strings into the sub table
-					$t = array_merge($t, Kohana::load($file));
+					$t = Arr::merge($t, Kohana::load($file));
 				}
 
 				// Append the sub table, preventing less specific language


### PR DESCRIPTION
If you have many modules with their own i18n folder and you want to rewrite or add new items to an specific group (array) with this little change now you can.

I have a helper module that contains most of the translations and text that I'm using in all my applications,, such as buttons, labels, menu options, etc. 

I use I18n::load('en') to get all the text and translations from all the modules that I am using in my applications, but with the array_merge doesn't include new or updated items in my applications.

That's why I'm requesting this little change to the Core.