### PR TITLE
Commands out of sync

### DIFF
--- a/modules/database/classes/Kohana/Database/MySQLi.php
+++ b/modules/database/classes/Kohana/Database/MySQLi.php
@@ -173,6 +173,9 @@ class Kohana_Database_MySQLi extends Database {
 				':query' => $sql
 			], $this->_connection->errno);
 		}
+		
+		do {}
+        	while (mysqli_more_results($this->_connection) AND mysqli_next_result($this->_connection));
 
 		if (isset($benchmark))
 		{


### PR DESCRIPTION
Hello.
MySQL was throwing this error: Commands out of sync; you can't run this command now.

The MySQL client does not allow you to execute a new query where there are still rows to be fetched from an in-progress query. See https://dev.mysql.com/doc/refman/8.0/en/commands-out-of-sync.html.

I found the solution here:  https://stackoverflow.com/questions/14715889/strict-standards-mysqli-next-result-error-with-mysqli-multi-query

Now everything is working perfectly fine.  Please let me know.