### PR TITLE
allows Response::send_file() to correctly send file resources

### DIFF
--- a/system/classes/Kohana/Response.php
+++ b/system/classes/Kohana/Response.php
@@ -382,6 +382,12 @@ class Kohana_Response implements HTTP_Response {
 	 *
 	 *     $request->send_file('media/packages/kohana.zip');
 	 *
+	 * Download a generated file:
+	 *
+	 *     $csv = tmpfile();
+	 *     fputcsv($csv, ['label1', 'label2']);
+	 *     $request->send_file($csv, $filename);
+	 *
 	 * Download generated content as a file:
 	 *
 	 *     $request->response($content);
@@ -389,7 +395,7 @@ class Kohana_Response implements HTTP_Response {
 	 *
 	 * [!!] No further processing can be done after this method is called!
 	 *
-	 * @param   string  $filename   filename with path, or TRUE for the current response
+	 * @param   string  $filename   filename with path, file stream resource, or TRUE for the current response
 	 * @param   string  $download   downloaded file name
 	 * @param   array   $options    additional options
 	 * @return  void
@@ -439,7 +445,12 @@ class Kohana_Response implements HTTP_Response {
 		}
 		else if ( ! empty($filename) && is_resource($filename))
 		{
-			// Handle files passed in as resources
+			if (empty($download))
+			{
+				throw new Kohana_Exception('Download name must be provided for streaming files');
+			}
+
+			// Handle file streams passed in as resources
 			$file = $filename;
 			$size = fstat($file)['size'];
 		}

--- a/system/classes/Kohana/Response.php
+++ b/system/classes/Kohana/Response.php
@@ -443,11 +443,18 @@ class Kohana_Response implements HTTP_Response {
 			// File data is no longer needed
 			unset($file_data);
 		}
-		else if ( ! empty($filename) && is_resource($filename))
+		else if (is_resource($filename) && get_resource_type($filename) === 'stream')
 		{
 			if (empty($download))
 			{
 				throw new Kohana_Exception('Download name must be provided for streaming files');
+			}
+
+			// Make sure this is a file handle
+			$file_meta = stream_get_meta_data($filename);
+			if ($file_meta['seekable'] === FALSE)
+			{
+				throw new Kohana_Exception('Resource must be a file handle');
 			}
 
 			// Handle file streams passed in as resources

--- a/system/classes/Kohana/Response.php
+++ b/system/classes/Kohana/Response.php
@@ -395,7 +395,7 @@ class Kohana_Response implements HTTP_Response {
 	 *
 	 * [!!] No further processing can be done after this method is called!
 	 *
-	 * @param   string  $filename   filename with path, file stream resource, or TRUE for the current response
+	 * @param   string|resource|bool $filename filename with path, file stream, or TRUE for the current response
 	 * @param   string  $download   downloaded file name
 	 * @param   array   $options    additional options
 	 * @return  void

--- a/system/classes/Kohana/Response.php
+++ b/system/classes/Kohana/Response.php
@@ -437,6 +437,12 @@ class Kohana_Response implements HTTP_Response {
 			// File data is no longer needed
 			unset($file_data);
 		}
+		else if ( ! empty($filename) && is_resource($filename))
+		{
+			// Handle files passed in as resources
+			$file = $filename;
+			$size = fstat($file)['size'];
+		}
 		else
 		{
 			// Get the complete file path


### PR DESCRIPTION
This is a pretty straightforward fix that lets Koseven code generate files for download using tmpfile()