### PR TITLE
Add JSON field type to MySQLi Driver

### DIFF
--- a/modules/database/classes/Kohana/Database/MySQLi.php
+++ b/modules/database/classes/Kohana/Database/MySQLi.php
@@ -222,6 +222,7 @@ class Kohana_Database_MySQLi extends Database {
 			'integer unsigned'          => ['type' => 'int', 'min' => '0', 'max' => '4294967295'],
 			'longblob'                  => ['type' => 'string', 'binary' => TRUE, 'character_maximum_length' => '4294967295'],
 			'longtext'                  => ['type' => 'string', 'character_maximum_length' => '4294967295'],
+			'json'                      => ['type' => 'string', 'character_maximum_length' => '4294967295'],
 			'mediumblob'                => ['type' => 'string', 'binary' => TRUE, 'character_maximum_length' => '16777215'],
 			'mediumint'                 => ['type' => 'int', 'min' => '-8388608', 'max' => '8388607'],
 			'mediumint unsigned'        => ['type' => 'int', 'min' => '0', 'max' => '16777215'],
@@ -379,6 +380,7 @@ class Kohana_Database_MySQLi extends Database {
 						case 'tinytext':
 						case 'mediumtext':
 						case 'longtext':
+						case 'json':
 							$column['collation_name'] = $row['Collation'];
 						break;
 						case 'enum':


### PR DESCRIPTION
"JSON" is an alias field type for "LONGTEXT". This edit make MySQLi Driver compatible to use "JSON" field type.