### PR TITLE
Travis CI Configuration Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 # Project language is PHP7
 language: php
 
-# Test on multiple Operating systems
-os:
-  - linux
-
-# Linux OS should be trusty (16.04)
-matrix:
-  include:
-    - os: linux
-      dist: xenial
+# Test on Ubuntu Xenial (16.04)
+dist: xenial
 
 # Supported PHP-Versions
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ php:
 matrix:
   include:
     - dist: trusty
+      php: 7.0
+    - dist: trusty
+      php: 7.1
+    - dist: trusty
+      php: 7.2
 
 # Services to start (with their default configuration)
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ install:
   - printf "\n" | pecl install -f redis
   - printf "\n" | pecl install -f imagick
   - printf "\n" | pecl install -f apcu
-  - printf "\n" | pecl install -f apcu_bc
 
 # Execute commands before executing script (e.g Add extensions to php.ini)
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ php:
   - 7.1
   - 7.2
 
+# Also Test on Trusty (14.04 LTS)
+matrix:
+  include:
+    - dist: trusty
+
 # Services to start (with their default configuration)
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Project language is PHP7
+# Project language is PHP
 language: php
 
 # Test on Ubuntu Xenial (16.04)
@@ -25,7 +25,6 @@ install:
 
 # Execute commands before executing script (e.g Add extensions to php.ini)
 before_script:
-  - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 # Execute commands which should make the build pass or fail

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ language: php
 # Test on multiple Operating systems
 os:
   - linux
-  - windows
 
-# Linux OS should be trusty (14.04.5 LTS) @TODO Maybe update linux os?
+# Linux OS should be trusty (16.04)
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
 
 # Supported PHP-Versions
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,15 @@ before_install:
 # Install dependencies
 install:
   - composer install
-  - pecl -q install redis
-  - pecl -q install memcached
-  - pecl -q install apcu
+  - printf "\n" | pecl install -f redis
+  - printf "\n" | pecl install -f imagick
+  - printf "\n" | pecl install -f apcu
+  - printf "\n" | pecl install -f apcu_bc
+
+# Execute commands before executing script (e.g Add extensions to php.ini)
+before_script:
+  - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 # Execute commands which should make the build pass or fail
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,17 @@ php:
   - 7.1
   - 7.2
 
+# Services to start (with their default configuration)
+services:
+  - redis-server
+  - memcached
+  - mysql
+
 # Execute this commands before installing dependencies
 before_install:
   - composer self-update
   - composer validate
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS unittest;'
 
 # Install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,40 @@
-dist: trusty
+# Project language is PHP7
 language: php
 
+# Test on multiple Operating systems
+os:
+  - linux
+  - windows
+
+# Linux OS should be trusty (14.04.5 LTS) @TODO Maybe update linux os?
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+
+# Supported PHP-Versions
 php:
   - 7.0
   - 7.1
   - 7.2
 
-before_script: 
+# Execute this commands before installing dependencies
+before_install:
+  - composer self-update
+  - composer validate
+
+# Install dependencies
+install:
   - composer install
 
+# Execute commands which should make the build pass or fail
 script:
   - vendor/bin/phpunit
 
+# Execute commands which should run after successful build
 after_success:
   - travis_retry vendor/bin/php-coveralls
 
+# Disable E-Mail notifications
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ before_install:
 # Install dependencies
 install:
   - composer install
+  - pecl -q install redis
+  - pecl -q install memcached
+  - pecl -q install apcu
 
 # Execute commands which should make the build pass or fail
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # Project language is PHP
 language: php
 
+# Use containerized infrastructure
+sudo: false
+
 # Test on Ubuntu Xenial (16.04)
 dist: xenial
 
@@ -9,6 +12,11 @@ php:
   - 7.0
   - 7.1
   - 7.2
+
+# Cache Composer's cache
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 # Also Test on Trusty (14.04 LTS)
 matrix:


### PR DESCRIPTION
Updated our travis configuration:

Updated distribution from Ubuntu 14.04 to 16.04
Added the following services (which run with their default configuration) and can be used for unittesting:

```
redis-server
memcached
mysql
```
Created a database `unittest`.

Added the following PHP Extensions (required to run some unittests - which will also incrase our coverage if we change a few lines):

```
redis
imagick
apcu
memcached
```

Last but not least added:

`composer self-update` (to keep composer itself up to date)
`composer validate` (which will check if composer.json is valid)

Devel branch passes build test with this configuration, so i am pretty sure this can be merged into devel!