### PR TITLE
Update to Inflector 'irregular' english plurals

### DIFF
--- a/system/config/inflector.php
+++ b/system/config/inflector.php
@@ -68,6 +68,7 @@ return [
 		'is'          => 'are',
 		'knife'       => 'knives',
 		'leaf'        => 'leaves',
+		'license'     => 'licenses',
 		'life'        => 'lives',
 		'loaf'        => 'loaves',
 		'man'         => 'men',


### PR DESCRIPTION
Added 'license' => 'licenses' to the list of irregular plurals. While technically not an irregular noun. Inflector::singular('licenses') was outputting 'licens' as the singular.