### PR TITLE
Fix i18n

### DIFF
--- a/modules/kohana/views/kohana/error.php
+++ b/modules/kohana/views/kohana/error.php
@@ -1,14 +1,4 @@
 <?php
-//when exceptions where thrown we where getting a ErrorException [ Fatal Error ]: Call to undefined function __()
-//since i18n was not loaded yet. nasty but works...
-if (!function_exists('__'))
-{
-    function __($message,$variables = NULL)
-    {
-        return is_array($variables) ? strtr($message, $variables):$message;
-    }
-}
-
 // Unique error identifier
 $error_id = uniqid('error');
 
@@ -69,11 +59,11 @@ $error_id = uniqid('error');
 						<?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
                             <a href="#<?php echo $source_id ?>" onclick="return koggle('<?php echo $source_id ?>')"><?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]</a>
                         <?php else: ?>
-                            {<?php echo __('PHP internal call') ?>}
+                            {<?php echo I18n::get('PHP internal call') ?>}
                         <?php endif ?>
 					</span>
                         &raquo;
-                        <?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo __('arguments') ?></a><?php endif ?>)
+                        <?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo I18n::get('arguments') ?></a><?php endif ?>)
                     </p>
                     <?php if (isset($args_id)): ?>
                         <div id="<?php echo $args_id ?>" class="collapsed">
@@ -95,10 +85,10 @@ $error_id = uniqid('error');
             <?php endforeach ?>
         </ol>
     </div>
-    <h2><a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Environment') ?></a></h2>
+    <h2><a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo I18n::get('Environment') ?></a></h2>
     <div id="<?php echo $env_id ?>" class="content collapsed">
         <?php $included = get_included_files() ?>
-        <h3><a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Included files') ?></a> (<?php echo count($included) ?>)</h3>
+        <h3><a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo I18n::get('Included files') ?></a> (<?php echo count($included) ?>)</h3>
         <div id="<?php echo $env_id ?>" class="collapsed">
             <table cellspacing="0">
                 <?php foreach ($included as $file): ?>
@@ -109,7 +99,7 @@ $error_id = uniqid('error');
             </table>
         </div>
         <?php $included = get_loaded_extensions() ?>
-        <h3><a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Loaded extensions') ?></a> (<?php echo count($included) ?>)</h3>
+        <h3><a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo I18n::get('Loaded extensions') ?></a> (<?php echo count($included) ?>)</h3>
         <div id="<?php echo $env_id ?>" class="collapsed">
             <table cellspacing="0">
                 <?php foreach ($included as $file): ?>

--- a/modules/pagination/views/pagination/basic.php
+++ b/modules/pagination/views/pagination/basic.php
@@ -1,15 +1,15 @@
 <p class="pagination">
 
 	<?php if ($first_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($first_page)) ?>" rel="first"><?php echo __('First') ?></a>
+		<a href="<?php echo HTML::chars($page->url($first_page)) ?>" rel="first"><?php echo I18n::get('First') ?></a>
 	<?php else: ?>
-		<?php echo __('First') ?>
+		<?php echo I18n::get('First') ?>
 	<?php endif ?>
 
 	<?php if ($previous_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($previous_page)) ?>" rel="prev"><?php echo __('Previous') ?></a>
+		<a href="<?php echo HTML::chars($page->url($previous_page)) ?>" rel="prev"><?php echo I18n::get('Previous') ?></a>
 	<?php else: ?>
-		<?php echo __('Previous') ?>
+		<?php echo I18n::get('Previous') ?>
 	<?php endif ?>
 
 	<?php for ($i = 1; $i <= $total_pages; $i++): ?>
@@ -23,15 +23,15 @@
 	<?php endfor ?>
 
 	<?php if ($next_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo __('Next') ?></a>
+		<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo I18n::get('Next') ?></a>
 	<?php else: ?>
-		<?php echo __('Next') ?>
+		<?php echo I18n::get('Next') ?>
 	<?php endif ?>
 
 	<?php if ($last_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo __('Last') ?></a>
+		<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo I18n::get('Last') ?></a>
 	<?php else: ?>
-		<?php echo __('Last') ?>
+		<?php echo I18n::get('Last') ?>
 	<?php endif ?>
 
 </p><!-- .pagination -->

--- a/modules/pagination/views/pagination/floating.php
+++ b/modules/pagination/views/pagination/floating.php
@@ -58,15 +58,15 @@ for ($i = $n7; $i <= $n8; ++$i)
 <p class="pagination">
 
 	<?php if ($first_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($first_page)) ?>" rel="first"><?php echo __('First') ?></a>
+		<a href="<?php echo HTML::chars($page->url($first_page)) ?>" rel="first"><?php echo I18n::get('First') ?></a>
 	<?php else: ?>
-		<?php echo __('First') ?>
+		<?php echo I18n::get('First') ?>
 	<?php endif ?>
 
 	<?php if ($previous_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($previous_page)) ?>" rel="prev"><?php echo __('Previous') ?></a>
+		<a href="<?php echo HTML::chars($page->url($previous_page)) ?>" rel="prev"><?php echo I18n::get('Previous') ?></a>
 	<?php else: ?>
-		<?php echo __('Previous') ?>
+		<?php echo I18n::get('Previous') ?>
 	<?php endif ?>
 
 	<?php foreach ($links as $number => $content): ?>
@@ -80,15 +80,15 @@ for ($i = $n7; $i <= $n8; ++$i)
 	<?php endforeach ?>
 
 	<?php if ($next_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo __('Next') ?></a>
+		<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo I18n::get('Next') ?></a>
 	<?php else: ?>
-		<?php echo __('Next') ?>
+		<?php echo I18n::get('Next') ?>
 	<?php endif ?>
 
 	<?php if ($last_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo __('Last') ?></a>
+		<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo I18n::get('Last') ?></a>
 	<?php else: ?>
-		<?php echo __('Last') ?>
+		<?php echo I18n::get('Last') ?>
 	<?php endif ?>
 
 </p><!-- .pagination -->

--- a/modules/userguide/views/userguide/api/class.php
+++ b/modules/userguide/views/userguide/api/class.php
@@ -107,7 +107,7 @@ Class is not declared in a file, it is probably an internal <?php echo html::anc
 <dd><?php echo $prop->description ?></dd>
 <dd><?php echo $prop->value ?></dd>
 <?php if ($prop->default !== $prop->value): ?>
-<dd><small><?php echo __('Default value:') ?></small><br/><?php echo $prop->default ?></dd>
+<dd><small><?php echo I18n::get('Default value:') ?></small><br/><?php echo $prop->default ?></dd>
 <?php endif ?>
 <?php endforeach ?>
 </dl>

--- a/system/classes/Error/Exception.php
+++ b/system/classes/Error/Exception.php
@@ -1,0 +1,3 @@
+<?php
+
+class Error_Exception extends KO7_Error_Exception {}

--- a/system/classes/KO7/Core.php
+++ b/system/classes/KO7/Core.php
@@ -952,10 +952,10 @@ class KO7_Core {
 	}
 
 	/**
-	 * PHP error handler, converts all errors into ErrorExceptions. This handler
+	 * PHP error handler, converts all errors into Error_Exceptions. This handler
 	 * respects error_reporting settings.
 	 *
-	 * @throws  ErrorException
+	 * @throws  Error_Exception
 	 * @return  TRUE
 	 */
 	public static function error_handler($code, $error, $file = NULL, $line = NULL)
@@ -963,8 +963,8 @@ class KO7_Core {
 		if (error_reporting() & $code)
 		{
 			// This error is not suppressed by current error reporting settings
-			// Convert the error into an ErrorException
-			throw new ErrorException($error, $code, 0, $file, $line);
+			// Convert the error into an Error_Exception
+			throw new Error_Exception($error, NULL, $code, 0, $file, $line);
 		}
 
 		// Do not execute the PHP error handler
@@ -1005,7 +1005,7 @@ class KO7_Core {
 			ob_get_level() AND ob_clean();
 
 			// Fake an exception for nice debugging
-			KO7_Exception::handler(new ErrorException($error['message'], $error['type'], 0, $error['file'], $error['line']));
+			KO7_Exception::handler(new Error_Exception($error['message'], NULL, $error['type'], 0, $error['file'], $error['line']));
 
 			// Shutdown now to avoid a "death loop"
 			exit(1);

--- a/system/classes/KO7/Error/Exception.php
+++ b/system/classes/KO7/Error/Exception.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * KO7 Error Exception Class
+ */
+class KO7_Error_Exception extends ErrorException {
+
+	/**
+	 * Creates a new translated exception.
+	 *
+	 *     throw new KO7_Error_Exception('Something went terrible wrong, :user',
+	 *         array(':user' => $user));
+	 *
+	 * @param   string          $message    Error message
+	 * @param   array           $variables  Translation variables
+	 * @param   int             $code       The error code
+	 * @param   int             $severity   The severity level of the exception.
+	 * @param   string			$file 		The filename where the exception is thrown.
+	 * @param   int 			$line		The line number where the exception is thrown.
+	 * @param   Throwable       $previous   Previous throwable
+	 * @return  void
+	 */
+	public function __construct(string $message = '', array $variables = NULL, int $code = 0, int $severity = 1, string $file = __FILE__, int $line = __LINE__, $previous = NULL)
+	{
+		// Set the message
+		$message = I18n::get([$message, $variables]);
+
+		// Pass the message and integer code to the parent
+		parent::__construct($message, $code, $severity, $file, $line, $previous);
+	}
+
+}

--- a/system/classes/KO7/I18n.php
+++ b/system/classes/KO7/I18n.php
@@ -20,7 +20,7 @@
  * @package    KO7
  * @category   Base
  * @author     Koseven Team
- * @copyright  (c) 2008´- 2016 Kohana Team
+ * @copyright  (c) 2008 - 2016 Kohana Team
  * @copyright  (c) since  2018 Koseven Team
  * @license    https://koseven.ga/LICENSE.md
  */
@@ -123,7 +123,7 @@ class KO7_I18n {
 	/**
 	 * Returns the translation table for a given language.
 	 *
-	 *     // Get all defined Spanish messages.
+	 *     // Get all defined English messages.
 	 *     // This will look for translation inside 'i18n/en/us.php'
 	 * 	   // and overwrite the ones in 'i18n/en.php'
 	 *     $messages = I18n::load('en-us');

--- a/system/classes/KO7/I18n.php
+++ b/system/classes/KO7/I18n.php
@@ -79,7 +79,7 @@ class KO7_I18n {
 	 * @param   string		  $source Source Language
 	 * @return  string
 	 */
-	public static function get($string, string $lang = NULL, string $source = NULL) : string
+	public static function get($string, string $lang = NULL, string $source = NULL)
 	{
 		$values = [];
 

--- a/system/classes/KO7/I18n.php
+++ b/system/classes/KO7/I18n.php
@@ -182,9 +182,9 @@ if ( ! function_exists('__'))
 	 *
 	 * @uses    I18n::get
 	 *
-	 * @param   string  $string text to translate
-	 * @param   array   $values values to replace in the translated text
-	 * @param   string  $lang   source language
+	 * @param   string  $string  Text to translate
+	 * @param   array   $values  Values to replace in the translated text
+	 * @param   string  $lang    Source language
 	 *
 	 * @return  string
 	 */

--- a/system/classes/KO7/KO7/Exception.php
+++ b/system/classes/KO7/KO7/Exception.php
@@ -50,7 +50,7 @@ class KO7_KO7_Exception extends Exception {
     public function __construct($message = "", array $variables = NULL, $code = 0, Throwable $previous = NULL)
     {
         // Set the message
-        $message = __($message, $variables);
+        $message = I18n::get([$message, $variables]);
 
         // Pass the message and integer code to the parent
         parent::__construct($message, (int) $code, $previous);

--- a/system/classes/KO7/Upload.php
+++ b/system/classes/KO7/Upload.php
@@ -215,7 +215,7 @@ class KO7_Upload {
 				// Get the width and height from the uploaded image
 				list($width, $height) = getimagesize($file['tmp_name']);
 			}
-			catch (ErrorException $e)
+			catch (Error_Exception $e)
 			{
 				// Ignore read errors
 			}

--- a/system/classes/KO7/Validation.php
+++ b/system/classes/KO7/Validation.php
@@ -505,12 +505,12 @@ class KO7_Validation implements ArrayAccess {
 				if (is_string($translate))
 				{
 					// Translate the label using the specified language
-					$label = __($label, NULL, $translate);
+					$label = I18n::get($label, NULL, $translate);
 				}
 				else
 				{
 					// Translate the label
-					$label = __($label);
+					$label = I18n::get($label);
 				}
 			}
 
@@ -552,12 +552,12 @@ class KO7_Validation implements ArrayAccess {
 							if (is_string($translate))
 							{
 								// Translate the value using the specified language
-								$value = __($value, NULL, $translate);
+								$value = I18n::get($value, NULL, $translate);
 							}
 							else
 							{
 								// Translate the value
-								$value = __($value);
+								$value = I18n::get($value);
 							}
 						}
 					}
@@ -594,12 +594,12 @@ class KO7_Validation implements ArrayAccess {
 				if (is_string($translate))
 				{
 					// Translate the message using specified language
-					$message = __($message, $values, $translate);
+					$message = I18n::get([$message, $values], NULL, $translate);
 				}
 				else
 				{
 					// Translate the message using the default language
-					$message = __($message, $values);
+					$message = I18n::get([$message, $values]);
 				}
 			}
 			else

--- a/system/guide/ko7/errors.md
+++ b/system/guide/ko7/errors.md
@@ -1,6 +1,6 @@
 # Error/Exception Handling
 
-Koseven provides both an exception handler and an error handler that transforms errors into exceptions using PHP's [ErrorException](http://php.net/errorexception) class. Many details of the error and the internal state of the application is displayed by the handler:
+Koseven provides both an exception handler and an error handler that transforms errors into Error_Exceptions using PHP's [ErrorException](http://php.net/errorexception) class. Many details of the error and the internal state of the application is displayed by the handler:
 
 1. Exception class
 2. Error level

--- a/system/i18n/es.php
+++ b/system/i18n/es.php
@@ -4,5 +4,6 @@ return [
 
 	'Spanish' => 'Español',
 	'Hello, world!' => '¡Hola, mundo!',
+	'Good Morning :name!' => 'Buenos dias :name!'
 
 ];

--- a/system/i18n/fr.php
+++ b/system/i18n/fr.php
@@ -4,5 +4,6 @@ return [
 
 	'French' => 'Français',
 	'Hello, world!' => 'Bonjour, monde!',
+	'Good Morning :name!' => 'Bonjour :name!'
 
 ];

--- a/system/tests/ko7/I18nTest.php
+++ b/system/tests/ko7/I18nTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Tests KO7 i18n class
  *
@@ -9,9 +8,10 @@
  *
  * @package    KO7
  * @category   Tests
- * @author     Kohana Team
- * @author     Jeremy Bush <contractfrombelow@gmail.com>
- * @copyright  (c) Kohana Team
+ *
+ * @author     Kohana Team, Jeremy Bush <contractfrombelow@gmail.com>
+ * @copyright  (c) 2008´- 2016 Kohana Team
+ * @copyright  (c) since  2018 Koseven Team
  * @license    https://koseven.ga/LICENSE.md
  */
 class KO7_I18nTest extends Unittest_TestCase {
@@ -20,38 +20,40 @@ class KO7_I18nTest extends Unittest_TestCase {
 	 * Default values for the environment, see setEnvironment
 	 * @var array
 	 */
-	// @codingStandardsIgnoreStart
 	protected $environmentDefault =	[
-		'I18n::$lang' => 'en-us',
+		'I18n::$lang' => 'en-us'
 	];
-	// @codingStandardsIgnoreEnd
 
 	/**
 	 * Provides test data for test_lang()
 	 *
 	 * @return array
 	 */
-	public function provider_lang()
+	public function provider_lang() : array
 	{
 		return [
 			// $input, $expected_result
-			[NULL, 'en-us'],
-			['es-es', 'es-es'],
+			[
+				NULL, 'en-us'
+			],
+			[
+				'es-es', 'es-es'
+			],
 		];
 	}
 
 	/**
 	 * Tests I18n::lang()
 	 *
-	 * @test
 	 * @dataProvider provider_lang
+	 *
 	 * @param  boolean  $input     Input for I18n::lang
 	 * @param  boolean  $expected  Output for I18n::lang
 	 */
-	public function test_lang($input, $expected_result)
+	public function test_lang($input, $expected)
 	{
-		$this->assertSame($expected_result, I18n::lang($input));
-		$this->assertSame($expected_result, I18n::lang());
+		self::assertSame($expected, I18n::lang($input));
+		self::assertSame($expected, I18n::lang());
 	}
 
 	/**
@@ -59,10 +61,10 @@ class KO7_I18nTest extends Unittest_TestCase {
 	 *
 	 * @return array
 	 */
-	public function provider_get()
+	public function provider_get() : array
 	{
 		return [
-			// $value, $result
+			// $lang, $input, $expected
 			['en-us', 'Hello, world!', 'Hello, world!'],
 			['es-es', 'Hello, world!', '¡Hola, mundo!'],
 			['fr-fr', 'Hello, world!', 'Bonjour, monde!'],
@@ -72,19 +74,70 @@ class KO7_I18nTest extends Unittest_TestCase {
 	/**
 	 * Tests i18n::get()
 	 *
-	 * @test
 	 * @dataProvider provider_get
-	 * @param boolean $input  Input for File::mime
-	 * @param boolean $expected Output for File::mime
+	 *
+	 * @param string $lang      Target Language to translate to
+	 * @param string $input     Input Translation String
+	 * @param string $expected  Expected Result
 	 */
-	public function test_get($lang, $input, $expected)
+	public function test_get(string $lang, string $input, string $expected)
 	{
+		// Set Language
 		I18n::lang($lang);
-		$this->assertSame($expected, I18n::get($input));
 
-		// Test immediate translation, issue #3085
+		// Test I18n::get function
+		self::assertSame($expected, I18n::get($input));
+
+		// Test I18n::get function with source language same as target language (we don't expect to be translated)
+		self::assertSame($input, I18n::get($input, $lang, $lang));
+
+		// Test __() function
+		self::assertSame($expected, __($input));
+
+		// Test __() function with source language (Note: we don't expect the string to be translated)
+		self::assertSame($input, __($input, NULL, $lang));
+
+		// Test I18n::get function with target language passed as variable
 		I18n::lang('en-us');
-		$this->assertSame($expected, I18n::get($input, $lang));
+		self::assertSame($expected, I18n::get($input, $lang));
+	}
+
+	/**
+	 * @return array
+	 */
+	public function provider_get_values() :array
+	{
+		return [
+			// $lang, $input, $values, $expected
+			['en-us', 'Good Morning :name!', [':name' => 'Koseven'], 'Good Morning Koseven!'],
+			['es-es', 'Good Morning :name!', [':name' => 'Koseven'], 'Buenos dias Koseven!'],
+			['fr-fr', 'Good Morning :name!', [':name' => 'Koseven'], 'Bonjour Koseven!'],
+		];
+	}
+
+	/**
+	 * Tests i18n::get with values passed to replace
+	 *
+	 * @dataProvider provider_get_values
+	 *
+	 * @param string $lang      Target Language to translate to
+	 * @param string $input     Input Translation String
+	 * @param array  $values    Values to replace in translated string
+	 * @param string $expected  Expected Result
+	 */
+	public function test_get_values(string $lang, string $input, array $values, string $expected)
+	{
+		// Set Language
+		I18n::lang($lang);
+
+		// Test I18n::get function with values to replace
+		self::assertSame($expected, I18n::get([$input, $values]));
+
+		// Test __() function with values to replace
+		self::assertSame($expected, __($input, $values));
+
+		// Don't expect string to be translated but expect values to be re-placed
+		self::assertSame('Good Morning Koseven!', I18n::get([$input, $values], $lang, $lang));
 	}
 
 }

--- a/system/views/ko7/error.php
+++ b/system/views/ko7/error.php
@@ -1,14 +1,4 @@
 <?php
-//when exceptions where thrown we where getting a ErrorException [ Fatal Error ]: Call to undefined function __()
-//since i18n was not loaded yet. nasty but works...
-if (!function_exists('__'))
-{
-    function __($message,$variables = NULL)
-    {
-	return is_array($variables) ? strtr($message, $variables):$message;
-    }
-}
-
 // Unique error identifier
 $error_id = uniqid('error', false);
 
@@ -85,14 +75,14 @@ $error_id = uniqid('error', false);
                                         <?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]
                                     </a>
                                 <?php else: ?>
-                                    {<?php echo __('PHP internal call') ?>}
+                                    {<?php echo I18n::get('PHP internal call') ?>}
                                 <?php endif ?>
                             </span>
                             &raquo;
                             <?php echo $step['function'] ?>(
                                 <?php if ($step['args']): $args_id = $error_id.'args'.$i; ?>
                                     <a href="#<?php echo $args_id ?>" onclick="return toggle('<?php echo $args_id ?>')">
-                                        <?php echo __('arguments') ?>
+                                        <?php echo I18n::get('arguments') ?>
                                     </a>
                                 <?php endif ?>
                             )
@@ -121,13 +111,13 @@ $error_id = uniqid('error', false);
             </div>
             <h2>
                 <a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return toggle('<?php echo $env_id ?>')">
-                    <?php echo __('Environment') ?>
+                    <?php echo I18n::get('Environment') ?>
                 </a>
             </h2>
             <div id="<?php echo $env_id ?>" class="content collapsed">
                 <?php $included = get_included_files() ?>
                 <h3>
-                    <a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return toggle('<?php echo $env_id ?>')"><?php echo __('Included files') ?></a>
+                    <a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return toggle('<?php echo $env_id ?>')"><?php echo I18n::get('Included files') ?></a>
                     (<?php echo count($included) ?>)
                 </h3>
                 <div id="<?php echo $env_id ?>" class="collapsed">
@@ -141,7 +131,7 @@ $error_id = uniqid('error', false);
                 </div>
                 <?php $included = get_loaded_extensions() ?>
                 <h3>
-                    <a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return toggle('<?php echo $env_id ?>')"><?php echo __('Loaded extensions') ?></a>
+                    <a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return toggle('<?php echo $env_id ?>')"><?php echo I18n::get('Loaded extensions') ?></a>
                     (<?php echo count($included) ?>)
                 </h3>
                 <div id="<?php echo $env_id ?>" class="collapsed">

--- a/system/views/profiler/stats.php
+++ b/system/views/profiler/stats.php
@@ -12,16 +12,16 @@ $application_cols = ['min', 'max', 'average', 'current'];
 	<?php foreach (Profiler::groups() as $group => $benchmarks): ?>
 	<table class="profiler">
 		<tr class="group">
-			<th class="name" rowspan="2"><?php echo __(ucfirst($group)) ?></th>
+			<th class="name" rowspan="2"><?php echo I18n::get(ucfirst($group)) ?></th>
 			<td class="time" colspan="4"><?php echo number_format($group_stats[$group]['total']['time'], 6) ?> <abbr title="seconds">s</abbr></td>
 		</tr>
 		<tr class="group">
 			<td class="memory" colspan="4"><?php echo number_format($group_stats[$group]['total']['memory'] / 1024, 4) ?> <abbr title="kilobyte">kB</abbr></td>
 		</tr>
 		<tr class="headers">
-			<th class="name"><?php echo __('Benchmark') ?></th>
+			<th class="name"><?php echo I18n::get('Benchmark') ?></th>
 			<?php foreach ($group_cols as $key): ?>
-			<th class="<?php echo $key ?>"><?php echo __(ucfirst($key)) ?></th>
+			<th class="<?php echo $key ?>"><?php echo I18n::get(ucfirst($key)) ?></th>
 			<?php endforeach ?>
 		</tr>
 		<?php foreach ($benchmarks as $name => $tokens): ?>
@@ -58,7 +58,7 @@ $application_cols = ['min', 'max', 'average', 'current'];
 	<table class="profiler">
 		<?php $stats = Profiler::application() ?>
 		<tr class="final mark time">
-			<th class="name" rowspan="2" scope="rowgroup"><?php echo __('Application Execution').' ('.$stats['count'].')' ?></th>
+			<th class="name" rowspan="2" scope="rowgroup"><?php echo I18n::get('Application Execution').' ('.$stats['count'].')' ?></th>
 			<?php foreach ($application_cols as $key): ?>
 			<td class="<?php echo $key ?>"><?php echo number_format($stats[$key]['time'], 6) ?> <abbr title="seconds">s</abbr></td>
 			<?php endforeach ?>


### PR DESCRIPTION
# Details

This PR adds an Error_Exception Class which extends ErrorException (with additional support of translation).

It also makes sure translation function` __()` is only used in APPATH. In MODPATH and SYSPATH `I18n::get()` function is used.

### Related Issue

Fixes Issue #293 completley.
Also fixes PR #292 

### How Has This Been Tested

Tested with unittests.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
