### PR TITLE
Webp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@ nbproject
 *.iml
 out
 gen
+
+# Unit tests
 .phpunit.result.cache
+modules/unittest/memory
 
 # Kohana template
 application/cache/*

--- a/modules/image/classes/KO7/Image.php
+++ b/modules/image/classes/KO7/Image.php
@@ -22,9 +22,6 @@ abstract class KO7_Image {
 	const HORIZONTAL = 0x11;
 	const VERTICAL   = 0x12;
 
-	// PHP image_type_to_mime_type doesn't know WEBP yet
-	const IMAGETYPE_WEBP = -1;
-
 	/**
 	 * @deprecated - provide an image.default_driver value in your configuration instead
 	 * @var  string  default driver: GD, ImageMagick, etc
@@ -678,7 +675,7 @@ abstract class KO7_Image {
 	 */
 	protected function image_type_to_mime_type($type)
 	{
-		if ($type === self::IMAGETYPE_WEBP)
+		if ($type === IMAGETYPE_WEBP)
 			return 'image/webp';
 
 		return image_type_to_mime_type($type);

--- a/modules/image/classes/KO7/Image/GD.php
+++ b/modules/image/classes/KO7/Image/GD.php
@@ -102,7 +102,7 @@ class KO7_Image_GD extends Image {
 			case IMAGETYPE_PNG:
 				$create = 'imagecreatefrompng';
 			break;
-			case self::IMAGETYPE_WEBP:
+			case IMAGETYPE_WEBP:
 				$create = 'imagecreatefromwebp';
 			break;
 		}
@@ -638,7 +638,7 @@ class KO7_Image_GD extends Image {
 			case 'webp':
 				// Save a WEBP file
 				$save = 'imagewebp';
-				$type = self::IMAGETYPE_WEBP;
+				$type = IMAGETYPE_WEBP;
 
 				$quality = 80;
 			break;

--- a/modules/image/classes/KO7/Image/Imagick.php
+++ b/modules/image/classes/KO7/Image/Imagick.php
@@ -321,7 +321,7 @@ class KO7_Image_Imagick extends Image {
 				$type = IMAGETYPE_PNG;
 			break;
 			case 'webp':
-				$type = SELF::IMAGETYPE_WEBP;
+				$type = IMAGETYPE_WEBP;
 			break;
 			default:
 				throw new KO7_Exception('Installed ImageMagick does not support :type images',


### PR DESCRIPTION
# PR Details

Builtin Support for WEBP images is available since PHP7.1+ therefore we can use it and remove the custom one. Note: also adding unittest files to .gitignore

### Related Issue

#326 

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
