### PR TITLE
Bug fixes 

### DIFF
--- a/system/classes/KO7/Valid.php
+++ b/system/classes/KO7/Valid.php
@@ -444,7 +444,7 @@ class KO7_Valid {
 		list($decimal) = array_values(localeconv());
 
 		// A lookahead is used to make sure the string contains at least one digit (before or after the decimal point)
-		return (bool) preg_match('/^-?+(?=.*[0-9])[0-9]*+'.preg_quote($decimal).'?+[0-9]*+$/D', (string) $str);
+		return (bool) preg_match('/^-?+(?=.*[0-9])[0-9]*+'.preg_quote($decimal , '/').'?+[0-9]*+$/D', (string) $str);
 	}
 
 	/**


### PR DESCRIPTION

 fixing the bug related to this error ```preg_match() unknown modifier```

# PR Details

when  `decimal_point`  is  ` '/' ` and it's not a special regular expression character. according to the manual: 

> delimiter
If the optional delimiter is specified, it will also be escaped. This is useful for escaping the delimiter that is required by the PCRE functions. The `' / '` is the most commonly used delimiter.

### Related Issue

Issue #351 

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
