### PR TITLE
Updated convention to not use short open tags

### DIFF
--- a/modules/orm/guide/orm/examples/validation.md
+++ b/modules/orm/guide/orm/examples/validation.md
@@ -57,18 +57,18 @@ This example will create user accounts and demonstrate how to handle model and c
 
 Please forgive my slightly ugly form. I am trying not to use any modules or unrelated magic. :)
 
-	<form action="<?= URL::site('/members'); ?>" method="post" accept-charset="utf-8">
+	<form action="<?php= URL::site('/members'); ?>" method="post" accept-charset="utf-8">
 		<label for="username">Username:</label>
-		<input id="username" type="text" name="username" value="<?= Arr::get($values, 'username'); ?>" />
-		<label for="username" class="error"><?= Arr::get($errors, 'username'); ?>
+		<input id="username" type="text" name="username" value="<?php= Arr::get($values, 'username'); ?>" />
+		<label for="username" class="error"><?php= Arr::get($errors, 'username'); ?>
 
 		<label for="password">Password:</label>
-		<input id="password" type="password" name="password" value="<?= Arr::get($values, 'password'); ?>" />
-		<label for="password" class="error"><?= Arr::get($errors, 'password'); ?>
+		<input id="password" type="password" name="password" value="<?php= Arr::get($values, 'password'); ?>" />
+		<label for="password" class="error"><?php= Arr::get($errors, 'password'); ?>
 
 		<label for="password_confirm">Repeat Password:</label>
-		<input id="password_confirm" type="password" name="_external[password_confirm]" value="<?= Arr::path($values, '_external.password_confirm'); ?>" />
-		<label for="password_confirm" class="error"><?= Arr::path($errors, '_external.password_confirm'); ?>
+		<input id="password_confirm" type="password" name="_external[password_confirm]" value="<?php= Arr::path($values, '_external.password_confirm'); ?>" />
+		<label for="password_confirm" class="error"><?php= Arr::path($errors, '_external.password_confirm'); ?>
 
 		<button type="submit">Create</button>
 	</form>

--- a/system/guide/ko7/conventions.md
+++ b/system/guide/ko7/conventions.md
@@ -2,6 +2,10 @@
 
 It is encouraged that you follow Koseven's coding style. This makes code more readable and allows for easier code sharing and contributing. 
 
+## General
+
+Since Short open tags `<?` will be deprecated in [7.4 and removed in 8.0](https://wiki.php.net/rfc/deprecate_php_short_tags) please only use `<?php`.
+
 ## Class Names and File Location
 
 Class names in Koseven follow a strict convention to facilitate [autoloading](autoloading). Class names should have uppercase first letters with underscores to separate words. Underscores are significant as they directly reflect the file location in the filesystem.

--- a/system/guide/ko7/tutorials/basic-controller.md
+++ b/system/guide/ko7/tutorials/basic-controller.md
@@ -69,7 +69,7 @@ Example of `layout.php`:
       </aside>
       <main>
         <!-- Render action template -->
-        <?=$main_content->render()?>
+        <?php=$main_content->render()?>
       </main>
       <footer>
         ...


### PR DESCRIPTION
Only adds the convention to not use short open tags #359 

only updated convention and examples in docs...no need for review