### PR TITLE
ORM->count_all() fixes

### DIFF
--- a/modules/orm/classes/Kohana/ORM.php
+++ b/modules/orm/classes/Kohana/ORM.php
@@ -1831,11 +1831,11 @@ class Kohana_ORM extends Model implements serializable {
 		}
 		if ( ! empty($this->_load_with))
 		{
-		    foreach ($this->_load_with as $alias)
-		    {
-			// Bind relationship
-			$this->with($alias);
-		    }
+			foreach ($this->_load_with as $alias)
+			{
+				// Bind relationship
+				$this->with($alias);
+			}
 		}
 
 		$this->_build(Database::SELECT);

--- a/modules/orm/classes/Kohana/ORM.php
+++ b/modules/orm/classes/Kohana/ORM.php
@@ -1829,6 +1829,7 @@ class Kohana_ORM extends Model implements serializable {
 				unset($this->_db_pending[$key]);
 			}
 		}
+
 		if ( ! empty($this->_load_with))
 		{
 			foreach ($this->_load_with as $alias)
@@ -1841,8 +1842,8 @@ class Kohana_ORM extends Model implements serializable {
 		$this->_build(Database::SELECT);
 
 		$records = $this->_db_builder->from([$this->_table_name, $this->_object_name])
-		    ->select([DB::expr('COUNT('.$this->_db->quote_column($this->_object_name.'.'.$this->_primary_key).')'), 'records_found'])
-		    ->execute($this->_db);
+			->select([DB::expr('COUNT('.$this->_db->quote_column($this->_object_name.'.'.$this->_primary_key).')'), 'records_found'])
+			->execute($this->_db);
 
 		// in rare use-cases where queries are grouped by their own model's primary key, 
 		// the correct count if the # of returned rows in the generated total query   

--- a/modules/orm/classes/Kohana/ORM.php
+++ b/modules/orm/classes/Kohana/ORM.php
@@ -1804,26 +1804,31 @@ class Kohana_ORM extends Model implements serializable {
 
 		foreach ($this->_db_pending as $key => $method)
 		{
-		    if ($method['name'] == 'select')
-		    {
-			// Ignore any selected columns for now
-			$removed_methods[$key] = $method;
-			unset($this->_db_pending[$key]);
-		    } elseif($method['name'] == 'group_by') {
-			// in instances where a query has to be grouped by the model's primary key
-			// the count(primary_key) inserted by the count all function creates a result for 
-			// every matched row instead of the count in the first result
-			if($method['args'][0] = $this->_object_name.'.'.$this->_primary_key) {
-			    $count_rows = true;
+			if ($method['name'] == 'select')
+			{
+				// Ignore any selected columns for now
+				$removed_methods[$key] = $method;
+				unset($this->_db_pending[$key]);
+		    	} 
+			elseif($method['name'] == 'group_by') 
+			{
+				/** 
+				* In instances where a query has to be grouped by the model's primary key
+				* the count(primary_key) inserted by the count all function creates a result for 
+				* every matched row instead of the count in the first result
+				*/
+				if($method['args'][0] = $this->_object_name.'.'.$this->_primary_key) 
+				{
+					$count_rows = true;
+				}
+			} 
+			elseif($method['name'] == 'order_by') 
+			{
+				// order bys don't help counting and may rely on created columns in the selects
+				$removed_methods[$key] = $method;
+				unset($this->_db_pending[$key]);
 			}
-		    } elseif($method['name'] == 'order_by') {
-			$removed_methods[$key] = $method;
-			// order by's don't help counting and may rely on created columns in the selects
-			// remove any order bys for the purpose of counting results
-			unset($this->_db_pending[$key]);
-		    }
 		}
-
 		if ( ! empty($this->_load_with))
 		{
 		    foreach ($this->_load_with as $alias)


### PR DESCRIPTION
Fixes so count_all() 
- Returns the correct # of rows for selects which have been grouped by the model's primary key 
- Doesn't throw an exception when the loaded query contains an order_by for a generated 'column' from an additional select().

# PR Details

- Update count_all logic to return the correct number of results for queries that group by their own primary key. 
- Stop exceptions being caused when the loaded query contains an order_by for a generated 'column' from an additional select().

### Description

In instances where tables were joined to count records matching tags (or similar) and a column was created via an additional select eg. `COUNT(stories.story_id) AS 'total_count' ... ORDER BY total_count DESC` the count_all() function used to setup pagination fails. 

Two errors exist:

1. Because the current count_all function clears all the SELECT params but leaves the ORDER BY methods, a mysql exception is thrown when the ORDER BY in the count_all query is on a field/column that doesn't exist. There's no reason for ORDER BY's to be included in a query to get the count of a result set so this change drops them by default and re-adds them after the count has been gotten. 
2. In queries where a join/outer join is looking to match many to many records for say 'tags' for each model, the query needs to group by the model's primary key so that only a single record of each matching model is returned. Where a model's query was grouped by its primary key because of a join, the current count_all function results in a query that generates multiple rows, one for each matching model with the count resulting in the number of successful records that were joined. In these instances the correct number of results for count_all is actually the number of rows returned by the query. There may be a quicker way to handle this but at least it provides the correct number of results in these instances.

### Related Issue

No issue exists. It was a bug I found and resolved as part of new functionality for an existing project. It's a non-breaking change so passing it back.

### How Has This Been Tested

Testing has been done with different models, queries, attached tables and other. The code has been tested and shown to return the right results in the instances it fixes and the same existing correct results for all other query types.

### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
