### PR TITLE
Switch to Codeconv

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ comment: off
 
 coverage:
   status:
-    project:
+    koseven:
       default: off
       application:
         target: 100%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+comment: off
+
+coverage:
+  status:
+    project:
+      default: off
+      application:
+        flags: application
+      modules:
+        flags: modules
+      system:
+        flags: system
+
+flags:
+  application:
+    paths:
+      - application/
+  modules:
+    paths:
+      - modules/
+  system:
+    paths:
+      - system/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  notify:
-    require_ci_to_pass: yes
-
 comment: off
 
 coverage:
@@ -9,10 +5,13 @@ coverage:
     project:
       default: off
       application:
+        target: 100%
         flags: application
       modules:
+        target: auto
         flags: modules
       system:
+        target: auto
         flags: system
 
 flags:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ comment: off
 
 coverage:
   status:
-    koseven:
+    project:
       default: off
       application:
         target: 100%

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,0 @@
-service_name: travis-ci
-coverage_clover: build/logs/clover.xml
-json_path: build/logs/coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ after_success:
   - ln -s $(pwd) /tmp/koseven
   - sudo chmod -R 777 build
   - sudo chmod -R 777 /tmp
-  - bash <(curl -s https://codecov.io/bash) -f /tmp/koseven/build/logs/clover.xml
+  - bash <(curl -s https://codecov.io/bash) -f /tmp/koseven/build/logs/clover.xml -F application
+  - bash <(curl -s https://codecov.io/bash) -f /tmp/koseven/build/logs/clover.xml -F modules
+  - bash <(curl -s https://codecov.io/bash) -f /tmp/koseven/build/logs/clover.xml -F system
 
 # Disable E-Mail notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ after_success:
   - ln -s $(pwd) /tmp/koseven
   - sudo chmod -R 777 build
   - sudo chmod -R 777 /tmp
-  - travis_retry vendor/bin/php-coveralls -v
+  - bash <(curl -s https://codecov.io/bash) -f /tmp/koseven/build/logs/clover.xml
 
 # Disable E-Mail notifications
 notifications:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Stable Version](https://poser.pugx.org/koseven/koseven/v/stable)](https://packagist.org/packages/koseven/koseven)
 [![Build Status](https://travis-ci.org/koseven/koseven.svg?branch=devel)](https://travis-ci.org/koseven/koseven)
-[![Coverage Status](https://coveralls.io/repos/github/koseven/koseven/badge.svg?branch=devel)](https://coveralls.io/github/koseven/koseven?branch=devel)
+[![Coverage Status](https://img.shields.io/codecov/c/github/koseven/koseven/devel)](https://codecov.io/gh/koseven/koseven)
 [![License](https://poser.pugx.org/koseven/koseven/license.svg)](https://packagist.org/packages/koseven/koseven)
 [![Github Issues](https://img.shields.io/github/issues/koseven/koseven.svg)](https://github.com/koseven/koseven/issues)
 [![Pending Pull-Requests](http://githubbadges.herokuapp.com/koseven/koseven/pulls.svg)](https://github.com/koseven/koseven/pulls)

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8",
-    "php-coveralls/php-coveralls": "^2.1.0",
     "internations/http-mock": "^0.12"
   },
   "conflict": {


### PR DESCRIPTION
Switch Coverage reporter to CodeConv:
- well maintained
- also free
- Allow us to easily differ between different folders (application, modules, system)