### PR TITLE
Cover NOT IN in addition to IN.

### DIFF
--- a/modules/database/classes/Kohana/Database/Query/Builder.php
+++ b/modules/database/classes/Kohana/Database/Query/Builder.php
@@ -110,7 +110,7 @@ abstract class Kohana_Database_Query_Builder extends Database_Query {
 						// Quote the min and max value
 						$value = $min.' AND '.$max;
 					}
-					elseif ($op === 'IN' AND is_array($value) AND count($value) === 0)
+					elseif (($op === 'IN' || $op === 'NOT IN') AND is_array($value) AND count($value) === 0)
 					{
 						$value = '(NULL)';
 					}

--- a/modules/database/classes/Kohana/Database/Query/Builder.php
+++ b/modules/database/classes/Kohana/Database/Query/Builder.php
@@ -110,7 +110,7 @@ abstract class Kohana_Database_Query_Builder extends Database_Query {
 						// Quote the min and max value
 						$value = $min.' AND '.$max;
 					}
-					elseif (($op === 'IN' || $op === 'NOT IN') AND is_array($value) AND count($value) === 0)
+					elseif (($op === 'IN' OR $op === 'NOT IN') AND is_array($value) AND count($value) === 0)
 					{
 						$value = '(NULL)';
 					}


### PR DESCRIPTION
Previously, Database_Exception would be thrown when trying...

` ->where($column, 'IN', []).`

`$value = '(NULL)'; `prevented this by making `IN () `convert to `IN (NULL)`

However, `NOT IN` was seemingly forgotten. `->where($column, 'NOT IN', [])` is just as valid.

This originates from https://github.com/koseven/koseven/issues/160

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
