### PR TITLE
Fixed regression in memcache service `instant_death` on failure

### DIFF
--- a/modules/cache/classes/Kohana/Cache/Memcache.php
+++ b/modules/cache/classes/Kohana/Cache/Memcache.php
@@ -289,7 +289,7 @@ class Kohana_Cache_Memcache extends Cache implements Cache_Arithmetic {
 	{
 		// This is for compatability with anyone using the config
 		// variable from Koseven initail update
-		if ($this->config('instant_death') === false)
+		if ($this->config('instant_death') === FALSE)
 			return;
 
 		// Setup non-existent host

--- a/modules/cache/classes/Kohana/Cache/Memcache.php
+++ b/modules/cache/classes/Kohana/Cache/Memcache.php
@@ -24,7 +24,7 @@
  *                              'timeout'          => 1,
  *                              'retry_interval'   => 15,
  *                              'status'           => TRUE,
- *				'instant_death'	   => TRUE,
+ *                              'instant_death'    => TRUE,
  *                              'failure_callback' => array('className', 'classMethod')
  *                         ),
  *                         // Second memcache server
@@ -287,7 +287,9 @@ class Kohana_Cache_Memcache extends Cache implements Cache_Arithmetic {
 	 */
 	public function _failed_request($hostname, $port)
 	{
-		if ( ! $this->_config['instant_death'])
+		// This is for compatability with anyone using the config
+		// variable from Koseven initail update
+		if ($this->config('instant_death') === false)
 			return;
 
 		// Setup non-existent host
@@ -301,6 +303,10 @@ class Kohana_Cache_Memcache extends Cache implements Cache_Arithmetic {
 			// We're looking at the failed server
 			if ($hostname == $server['host'] and $port == $server['port'])
 			{
+				// Make sure that we do not disable servers that have `instant_death` set to `FALSE`.
+				if ( ! $server['instant_death'])
+					continue;
+
 				// Server to disable, since it failed
 				$host = $server;
 				continue;


### PR DESCRIPTION
# PR Details

In this PR I am re-introducing functionality that had been removed when the repository was initialized.

### Description

When Koseven was cloned in it cointained a change in codebase of where we were calling the the `instant_death` variable when memcached fails.

This looks like a start of a change that was never finished. All documentation, other code and references point to the prior functionality.

### Changes
- Fixed regression in behaviour when disabling memcache server on failure per server
- Fixed calling an undocumented member of memcache configuration to prevent failure
- Fixed some indentation in a comment that has tabs in stead of spaces

### Related Issue
https://github.com/koseven/koseven/issues/429

### How Has This Been Tested
By running this on our production system without it gobbling errors every hour

### Types of changes

- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
