### PR TITLE
ErrorException [ Deprecated ]:

### DIFF
--- a/system/classes/Kohana/Arr.php
+++ b/system/classes/Kohana/Arr.php
@@ -101,7 +101,7 @@ class Kohana_Arr {
 		}
 		else
 		{
-			if (array_key_exists($path, $array))
+			if (isset($path, $array))
 			{
 				// No need to do extra processing
 				return $array[$path];


### PR DESCRIPTION
ErrorException [ Deprecated ]: array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead

# PR Details

Provide a general summary of your changes in the Title above

### Description

ErrorException [ Deprecated ]: array_key_exists(): 
Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead


### How Has This Been Tested

Minion error  then uncommet
Kohana::init  [
cache
]
