### PR TITLE
Update Session.php

### DIFF
--- a/system/classes/Kohana/Session.php
+++ b/system/classes/Kohana/Session.php
@@ -441,7 +441,7 @@ abstract class Kohana_Session {
 	 */
 	protected function _unserialize($data)
 	{
-		return unserialize($data);
+		return unserialize($data, ['allowed_classes' => false]);
 	}
 
 	/**


### PR DESCRIPTION
Adding $option param to unserialize. The allowed_classes element of options is now strictly typed, i.e. if anything other than an array or a bool is given, unserialize() returns FALSE and issues an E_WARNING.
