### PR TITLE
Bug Fix - REST.php

### DIFF
--- a/system/classes/KO7/Controller/REST.php
+++ b/system/classes/KO7/Controller/REST.php
@@ -126,11 +126,16 @@ abstract class KO7_Controller_REST extends Controller {
         {
             try
             {
-                $parsed_body = json_decode($this->request->body(), true, 512, JSON_THROW_ON_ERROR);
+                // Fix for PHP 7
+                // json_decode() throws and error when decoding an empty string
+                if ( ! empty($this->request->body()) )
+                {
+                    $parsed_body = json_decode($this->request->body(), true, 512, JSON_THROW_ON_ERROR);
+                }
             }
             catch (JsonException $e)
             {
-                throw new REST_Exception($e->getMessage(). NULL, $e->getCode(), $e);
+                throw new REST_Exception($e->getMessage(), NULL, $e->getCode(), $e);
             }
         }
         else


### PR DESCRIPTION
On PHP 7 json_decode() throws an error when decoding an empty string. Fix a typo on parameters on REST_Exception()

# PR Details

Provide a general summary of your changes in the Title above

### Description

Describe your changes in detail

### Related Issue

This project only accepts pull requests related to open issues

If suggesting a new feature or change, please discuss it in an issue first

If fixing a bug, there should be an issue describing it with steps to reproduce

Please link to the issue here

### How Has This Been Tested

Please describe in detail how you tested your changes and
see how your change affects other areas of the code, etc.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
