### PR TITLE
Bugfix for Issue #435

### DIFF
--- a/system/classes/Kohana/Debug.php
+++ b/system/classes/Kohana/Debug.php
@@ -202,7 +202,7 @@ class Kohana_Debug {
 				$objects[$hash] = TRUE;
 				foreach ($array as $key => & $val)
 				{
-					if ($key[0] === "\x00")
+					if (is_string($key) && $key && $key[0] === "\x00")
 					{
 						// Determine if the access is protected or protected
 						$access = '<small>'.(($key[1] === '*') ? 'protected' : 'private').'</small>';


### PR DESCRIPTION
Make sure debug key names are a valid string before checking individual characters using array syntax.

# PR Details

See above

### Description

Make sure debug key names are a valid string before checking individual characters using array syntax (eg. $string[0] == 'a'). Stops debug class throwing errors by trying to access characters of an integer using array (eg. $integer = 21, $integer[0] == Exception).

### Related Issue

https://github.com/koseven/koseven/issues/435### How Has This Been Tested

Please describe in detail how you tested your changes and
see how your change affects other areas of the code, etc.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
