### PR TITLE
Arr and Debug changes to resolve issue #435

### DIFF
--- a/system/classes/Kohana/Arr.php
+++ b/system/classes/Kohana/Arr.php
@@ -88,7 +88,7 @@ class Kohana_Arr {
 	 */
 	public static function path($array, $path, $default = NULL, $delimiter = NULL)
 	{
-		if ( ! Arr::is_array($array))
+		if ( ! is_array($array))
 		{
 			// This is not an array!
 			return $default;

--- a/system/classes/Kohana/Debug.php
+++ b/system/classes/Kohana/Debug.php
@@ -202,7 +202,7 @@ class Kohana_Debug {
 				$objects[$hash] = TRUE;
 				foreach ($array as $key => & $val)
 				{
-					if ($key[0] === "\x00")
+					if (is_string($key) && $key[0] === "\x00")
 					{
 						// Determine if the access is protected or protected
 						$access = '<small>'.(($key[1] === '*') ? 'protected' : 'private').'</small>';


### PR DESCRIPTION
# PR Details

Resolves Issue #435

### Description

Make sure debug key names are a valid string before checking individual characters using array syntax (eg. $string[0] == 'a'). Stops debug class throwing errors by trying to access characters of an integer using array (eg. $integer = 21, $integer[0] == Exception).
For this to work is also Makes Kohana_Arr::path() function use is_array instead of Arr::is_array when validating whether a var is an array as traversable objects could previously (prior to PHP 7.3) be addressed with array syntax but can no longer.

### Related Issue

Issue #435 

### How Has This Been Tested

Code exists for our app now in production. Tests have not been run on framework. 

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.