### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/modules/database/classes/Kohana/Database/Result.php
+++ b/modules/database/classes/Kohana/Database/Result.php
@@ -206,6 +206,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 *
 	 * @return  integer
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return $this->_total_rows;
@@ -222,6 +223,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 * @param   int     $offset
 	 * @return  boolean
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return ($offset >= 0 AND $offset < $this->_total_rows);
@@ -235,6 +237,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 * @param   int     $offset
 	 * @return  mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		if ( ! $this->seek($offset))
@@ -253,6 +256,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 * @return  void
 	 * @throws  Kohana_Exception
 	 */
+	#[\ReturnTypeWillChange]
 	final public function offsetSet($offset, $value)
 	{
 		throw new Kohana_Exception('Database results are read-only');
@@ -267,6 +271,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 * @return  void
 	 * @throws  Kohana_Exception
 	 */
+	#[\ReturnTypeWillChange]
 	final public function offsetUnset($offset)
 	{
 		throw new Kohana_Exception('Database results are read-only');
@@ -279,6 +284,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 *
 	 * @return  integer
 	 */
+	#[\ReturnTypeWillChange]
 	public function key()
 	{
 		return $this->_current_row;
@@ -291,6 +297,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 *
 	 * @return  $this
 	 */
+	#[\ReturnTypeWillChange]
 	public function next()
 	{
 		++$this->_current_row;
@@ -317,6 +324,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 *
 	 * @return  $this
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind()
 	{
 		$this->_current_row = 0;
@@ -330,6 +338,7 @@ abstract class Kohana_Database_Result implements Countable, Iterator, SeekableIt
 	 *
 	 * @return  boolean
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid()
 	{
 		return $this->offsetExists($this->_current_row);

--- a/modules/database/classes/Kohana/Database/Result/Cached.php
+++ b/modules/database/classes/Kohana/Database/Result/Cached.php
@@ -28,6 +28,7 @@ class Kohana_Database_Result_Cached extends Database_Result {
 		return $this;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function seek($offset)
 	{
 		if ($this->offsetExists($offset))
@@ -42,6 +43,7 @@ class Kohana_Database_Result_Cached extends Database_Result {
 		}
 	}
 
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		// Return an array of the row

--- a/modules/orm/classes/Kohana/ORM.php
+++ b/modules/orm/classes/Kohana/ORM.php
@@ -562,6 +562,17 @@ class Kohana_ORM extends Model implements serializable {
 		return (string) $this->pk();
 	}
 
+	public function __serialize(): array
+	{
+		// Store only information about the object
+		foreach (['_primary_key_value', '_object', '_changed', '_loaded', '_saved', '_sorting', '_original_values'] as $var)
+		{
+			$data[$var] = $this->{$var};
+		}
+
+		return $data;
+	}
+
 	/**
 	 * Allows serialization of only the object data and state, to prevent
 	 * "stale" objects being unserialized, which also requires less memory.
@@ -570,13 +581,7 @@ class Kohana_ORM extends Model implements serializable {
 	 */
 	public function serialize()
 	{
-		// Store only information about the object
-		foreach (['_primary_key_value', '_object', '_changed', '_loaded', '_saved', '_sorting', '_original_values'] as $var)
-		{
-			$data[$var] = $this->{$var};
-		}
-
-		return serialize($data);
+		return serialize($this->__serialize());
 	}
 
 	/**
@@ -593,18 +598,12 @@ class Kohana_ORM extends Model implements serializable {
 			: Arr::get($this->_changed, $field);
 	}
 
-	/**
-	 * Prepares the database connection and reloads the object.
-	 *
-	 * @param string $data String for unserialization
-	 * @return  void
-	 */
-	public function unserialize($data)
+	public function __unserialize($data)
 	{
 		// Initialize model
 		$this->_initialize();
 
-		foreach (unserialize($data) as $name => $var)
+		foreach ($data as $name => $var)
 		{
 			$this->{$name} = $var;
 		}
@@ -614,6 +613,17 @@ class Kohana_ORM extends Model implements serializable {
 			// Reload the object
 			$this->reload();
 		}
+	}
+
+	/**
+	 * Prepares the database connection and reloads the object.
+	 *
+	 * @param string $data String for unserialization
+	 * @return  void
+	 */
+	public function unserialize($data)
+	{
+		$this->__unserialize(unserialize($data));
 	}
 
 	/**

--- a/system/classes/Kohana/Config/Group.php
+++ b/system/classes/Kohana/Config/Group.php
@@ -121,6 +121,7 @@ class Kohana_Config_Group extends ArrayObject {
 	 * @param string $key   The key of the config item we're changing
 	 * @param mixed  $value The new array value
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($key, $value)
 	{
 		$this->_parent_instance->_write_config($this->_group_name, $key, $value);

--- a/system/classes/Kohana/HTTP/Header.php
+++ b/system/classes/Kohana/HTTP/Header.php
@@ -347,6 +347,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * @return  void
 	 * @since   3.2.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($index, $newval, $replace = TRUE)
 	{
 		// Ensure the index is lowercase
@@ -379,6 +380,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * @return  boolean
 	 * @since   3.2.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($index)
 	{
 		return parent::offsetExists(strtolower($index));
@@ -392,6 +394,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * @return  void
 	 * @since   3.2.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($index)
 	{
 		return parent::offsetUnset(strtolower($index));
@@ -405,6 +408,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * @return  mixed
 	 * @since   3.2.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($index)
 	{
 		return parent::offsetGet(strtolower($index));
@@ -418,6 +422,7 @@ class Kohana_HTTP_Header extends ArrayObject {
 	 * @return  array
 	 * @since   3.2.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function exchangeArray($input)
 	{
 		/**

--- a/system/classes/Kohana/Kohana/Exception.php
+++ b/system/classes/Kohana/Kohana/Exception.php
@@ -52,6 +52,8 @@ class Kohana_Kohana_Exception extends Exception {
         // Set the message
         $message = __($message, $variables);
 
+		if (is_null($message)) $message = '';
+
         // Pass the message and integer code to the parent
         parent::__construct($message, (int) $code, $previous);
 

--- a/system/classes/Kohana/Validation.php
+++ b/system/classes/Kohana/Validation.php
@@ -60,6 +60,7 @@ class Kohana_Validation implements ArrayAccess {
 	 * @param   mixed    $value     value to set
 	 * @return  void
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
 		throw new Kohana_Exception('Validation objects are read-only.');
@@ -72,6 +73,7 @@ class Kohana_Validation implements ArrayAccess {
 	 * @param   string  $offset key to check
 	 * @return  bool    whether the key is set
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return isset($this->_data[$offset]);
@@ -85,6 +87,7 @@ class Kohana_Validation implements ArrayAccess {
 	 * @param   string  $offset key to unset
 	 * @return  void
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{
 		throw new Kohana_Exception('Validation objects are read-only.');
@@ -97,6 +100,7 @@ class Kohana_Validation implements ArrayAccess {
 	 * @param   string  $offset key to return
 	 * @return  mixed   value from array
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		return $this->_data[$offset];


### PR DESCRIPTION
# PR Details

Make compatible with PHP 8.1

### Description

Mostly comments to loosen the type checks. The syntax for serialization in the ORM module had to be updated to be compatible with the new magic methods.

### Related Issue

This project only accepts pull requests related to open issues

If suggesting a new feature or change, please discuss it in an issue first

If fixing a bug, there should be an issue describing it with steps to reproduce

Please link to the issue here

### How Has This Been Tested

Tested in my app with PHP 8 and 8.1. I get the feeling there may need to be some more ReturnTypeWillChange additions as I didn't test all of the code.

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
