### PR TITLE
fix compatibility of GD for PHP8.0

### DIFF
--- a/modules/image/classes/Kohana/Image/GD.php
+++ b/modules/image/classes/Kohana/Image/GD.php
@@ -127,7 +127,7 @@ class Kohana_Image_GD extends Image {
 	 */
 	public function __destruct()
 	{
-		if (is_resource($this->_image))
+		if ( $this->_has_image() )
 		{
 			// Free all resources
 			imagedestroy($this->_image);
@@ -141,7 +141,7 @@ class Kohana_Image_GD extends Image {
 	 */
 	protected function _load_image()
 	{
-		if ( ! is_resource($this->_image))
+		if ( ! $this->_has_image() )
 		{
 			// Gets create function
 			$create = $this->_create_function;
@@ -152,6 +152,20 @@ class Kohana_Image_GD extends Image {
 			// Preserve transparency when saving
 			imagesavealpha($this->_image, TRUE);
 		}
+	}
+
+	/**
+	 * checks if an image has been set
+	 * 
+	 * @return boolean
+	 */
+	protected function _has_image()
+	{
+		if ( version_compare(PHP_VERSION, '8', '>=') )
+		{
+			return is_object($this->_image);
+		}
+		return is_resource($this->_image);
 	}
 
 	/**


### PR DESCRIPTION
# PR Details

Fix Kohana_Image_GD for PHP 8.0 in 3.3.x branch

### Description

Kohana_Image_GD checks for is_resource() while PHP return an object.
https://www.php.net/manual/en/class.gdimage.php



### Related Issue

#433

### How Has This Been Tested

Has been tested in multiple private projects.
Is fully backwards compatible.


### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
