### PR TITLE
Fix for Issue #466 - Arr::path to check for array and/or traversable …

### DIFF
--- a/system/classes/Kohana/Arr.php
+++ b/system/classes/Kohana/Arr.php
@@ -88,7 +88,7 @@ class Kohana_Arr {
 	 */
 	public static function path($array, $path, $default = NULL, $delimiter = NULL)
 	{
-		if ( ! is_array($array))
+		if ( ! Arr::is_array($array))
 		{
 			// This is not an array!
 			return $default;


### PR DESCRIPTION
Use Arr::is_array() to return correct bool value for checking against an array and/or traversable object.

# PR Details

Using just is_array() was returning false in case of traversable object. This broke the dot notation when getting back the config files values.

### Description

Used helper function Arr::is_array() that check for an array or traversable object.

### Related Issue

It's provided as a fix for [https://github.com/https://github.com/koseven/koseven/issues/466](Issue https://github.com/koseven/koseven/issues/466)

### How Has This Been Tested

Small change, quick smoke test

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
