### PR TITLE
remove deprecated predefined constant

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -227,7 +227,7 @@
                 <?php if (extension_loaded('mbstring')): ?>
                 <tr>
                     <th>Mbstring Not Overloaded</th>
-                    <?php if (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING): $failed = TRUE ?>
+                    <?php if (ini_get('mbstring.func_overload') ): $failed = TRUE ?>
                     <td class="fail">The <a href="http://php.net/mbstring">mbstring</a> extension is overloading PHP's native string functions.</td>
                     <?php else: ?>
                     <td class="pass">Pass</td>


### PR DESCRIPTION
# PR Details

Remove deprecated MB_OVERLOAD_STRING from install.php
https://www.php.net/manual/en/mbstring.constants.php


### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
