### PR TITLE
fix iterator compatibility

### DIFF
--- a/modules/database/classes/Kohana/Database/MySQLi/Result.php
+++ b/modules/database/classes/Kohana/Database/MySQLi/Result.php
@@ -28,6 +28,7 @@ class Kohana_Database_MySQLi_Result extends Database_Result {
 		}
 	}
 
+	#[ReturnTypeWillChange]
 	public function seek($offset)
 	{
 		if ($this->offsetExists($offset) AND $this->_result->data_seek($offset))
@@ -43,6 +44,7 @@ class Kohana_Database_MySQLi_Result extends Database_Result {
 		}
 	}
 
+	#[ReturnTypeWillChange]
 	public function current()
 	{
 		if ($this->_current_row !== $this->_internal_row AND ! $this->seek($this->_current_row))


### PR DESCRIPTION
### Description
The MySQLi_Result class was throwing deprecation errors for changing return types
The addition of 2 #[ReturnTypeWillChange] ensures this works out of the box  without breaking compatibility

### Related Issue
#471 

### How Has This Been Tested
Tested in development

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
