### PR TITLE
Update URL.php

### DIFF
--- a/system/classes/Kohana/URL.php
+++ b/system/classes/Kohana/URL.php
@@ -151,6 +151,9 @@ class Kohana_URL {
 	 */
 	public static function site($uri = '', $protocol = NULL, $index = TRUE, $subdomain = NULL)
 	{
+		if (is_null($uri))
+            		$uri = '';
+		
 		// Chop off possible scheme, host, port, user and pass parts
 		$path = preg_replace('~^[-a-z0-9+.]++://[^/]++/?~', '', trim($uri, '/'));
 

--- a/system/classes/Kohana/URL.php
+++ b/system/classes/Kohana/URL.php
@@ -149,10 +149,10 @@ class Kohana_URL {
 	 * @return  string
 	 * @uses    URL::base
 	 */
-	public static function site(string $uri = '', $protocol = NULL, $index = TRUE, $subdomain = NULL)
+	public static function site($uri = '', $protocol = NULL, $index = TRUE, $subdomain = NULL)
 	{	
 		// Chop off possible scheme, host, port, user and pass parts
-		$path = preg_replace('~^[-a-z0-9+.]++://[^/]++/?~', '', trim($uri, '/'));
+		$path = preg_replace('~^[-a-z0-9+.]++://[^/]++/?~', '', trim(($uri ?? ''), '/'));
 
 		if ( ! UTF8::is_ascii($path))
 		{

--- a/system/classes/Kohana/URL.php
+++ b/system/classes/Kohana/URL.php
@@ -149,11 +149,8 @@ class Kohana_URL {
 	 * @return  string
 	 * @uses    URL::base
 	 */
-	public static function site($uri = '', $protocol = NULL, $index = TRUE, $subdomain = NULL)
-	{
-		if (is_null($uri))
-            		$uri = '';
-		
+	public static function site(string $uri = '', $protocol = NULL, $index = TRUE, $subdomain = NULL)
+	{	
 		// Chop off possible scheme, host, port, user and pass parts
 		$path = preg_replace('~^[-a-z0-9+.]++://[^/]++/?~', '', trim($uri, '/'));
 


### PR DESCRIPTION
ErrorException [ Deprecated ]: trim(): Passing null to parameter #1 ($string) of type string is deprecated in PHP 8.1

# PR Details

Provide a general summary of your changes in the Title above

### Description

Describe your changes in detail

### Related Issue

This project only accepts pull requests related to open issues

If suggesting a new feature or change, please discuss it in an issue first

If fixing a bug, there should be an issue describing it with steps to reproduce

Please link to the issue here

### How Has This Been Tested

Please describe in detail how you tested your changes and
see how your change affects other areas of the code, etc.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
