### PR TITLE
Telegram Bug repoort: code fix uniqid

### DIFF
--- a/modules/database/classes/Kohana/Session/Database.php
+++ b/modules/database/classes/Kohana/Session/Database.php
@@ -125,7 +125,7 @@ class Kohana_Session_Database extends Session {
 		do
 		{
 			// Create a new session id
-			$id = str_replace('.', '-', uniqid(NULL, TRUE));
+			$id = str_replace('.', '-', uniqid('', TRUE));
 
 			// Get the the id from the database
 			$result = $query->execute($this->_db);


### PR DESCRIPTION
uniqid(): Passing null to parameter #1 ($prefix) of type string is deprecated

