### PR TITLE
fix deprecated strftime

### DIFF
--- a/system/classes/Kohana/Date.php
+++ b/system/classes/Kohana/Date.php
@@ -279,9 +279,31 @@ class Kohana_Date {
 
 		if ($format === Date::MONTHS_LONG OR $format === Date::MONTHS_SHORT)
 		{
-			for ($i = 1; $i <= 12; ++$i)
+			if ( version_compare(PHP_VERSION, '8.1', '<') )
 			{
-				$months[$i] = strftime($format, mktime(0, 0, 0, $i, 1));
+				$parser = function($time) use ($format) {
+					return strftime($format, $time);
+				};
+			}
+			elseif ( extension_loaded('intl') )
+			{
+				$parser = function($time) use ($format)
+				{
+					$formatter = new \IntlDateFormatter(null);
+					$formatter->setPattern($format === Date::MONTHS_LONG ? 'MMMM' : 'MMM');
+					return $formatter->format($time);
+				};
+			} 
+			else 
+			{
+				$parser = function($time) use ($format)
+				{
+					return date($format === Date::MONTHS_LONG ? 'F' : 'M', $time);
+				};
+			}
+			for ( $i = 1; $i <= 12; ++$i )
+			{
+				$months[$i] = $parser(mktime(0, 0, 0, $i, 1));
 			}
 		}
 		else


### PR DESCRIPTION
# PR Details
Kohana_Date::months() uses strftime to show local month names, This function has been deprecated from PHP 8.1.0:
https://www.php.net/manual/en/function.strftime.php

### Description
This is a potential fix.
I tried to keep this as backward compatible as possible.
Be aware the returned result could be different, depending on your local settings and environment.

### Related Issue
Related to #471 

### How Has This Been Tested
In testing environment

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
