### PR TITLE
Update Valid.php

### DIFF
--- a/system/classes/Kohana/Valid.php
+++ b/system/classes/Kohana/Valid.php
@@ -109,13 +109,13 @@ class Kohana_Valid {
     public static function email($email, $strict = FALSE)
     {
         if ($strict)
-        {
-            return filter_var(filter_var($email, FILTER_SANITIZE_STRING), FILTER_VALIDATE_EMAIL) !== FALSE;
-        }
-        else
-        {
-            return filter_var($email, FILTER_VALIDATE_EMAIL) !== FALSE;
-        }
+	{
+	    return filter_var(filter_var($email, FILTER_SANITIZE_EMAIL), FILTER_VALIDATE_EMAIL) !== NULL;
+	}
+	else
+	{
+	    return filter_var($email, FILTER_VALIDATE_EMAIL) !== NULL;
+	}
     }
 
 	/**


### PR DESCRIPTION
In PHP 8.1, the FILTER_SANITIZE_STRING filter constant has been deprecated, and FILTER_SANITIZE_EMAIL should be used instead. Additionally, the FILTER_VALIDATE_EMAIL filter does not return FALSE on failure; instead, it returns the filtered email address on success or NULL on failure.

# PR Details

Provide a general summary of your changes in the Title above

### Description

Describe your changes in detail

### Related Issue

This project only accepts pull requests related to open issues

If suggesting a new feature or change, please discuss it in an issue first

If fixing a bug, there should be an issue describing it with steps to reproduce

Please link to the issue here

### How Has This Been Tested

Please describe in detail how you tested your changes and
see how your change affects other areas of the code, etc.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
