### PR TITLE
Php83 fix header

### DIFF
--- a/system/classes/KO7/HTTP/Header.php
+++ b/system/classes/KO7/HTTP/Header.php
@@ -356,6 +356,7 @@ class KO7_HTTP_Header extends ArrayObject {
 		if ($replace OR ! $this->offsetExists($index))
 		{
 			parent::offsetSet($index, $newval);
+			return;
 		}
 
 		$current_value = $this->offsetGet($index);


### PR DESCRIPTION
# PR Details

Fixed Header::offsetSet

### Description

The method should return after setting the value, otherwise it will be set twice.
This error was introduced in commit 900e002

### How Has This Been Tested

In development

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
