### PR TITLE
Fix unittest, move to PHP >=8.3

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=koseven

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,8 @@ on: [push,pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 
+      labels: [self-hosted, k3s]
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Install composer dependencies
         run: docker exec unittest /bin/sh -c "service redis-server start; cd /tmp/koseven; composer install"
 
-      - name: Run Koseven Unittest(s) PHP 8.3
+      - name: Run Koseven Unittest(s) PHP8.3
         run: docker exec unittest /bin/sh -c "cd /tmp/koseven; php vendor/bin/phpunit"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
 name: Koseven
-
 on: [push,pull_request]
 
 jobs:
@@ -17,5 +16,5 @@ jobs:
       - name: Install composer dependencies
         run: docker exec unittest /bin/sh -c "service redis-server start; cd /tmp/koseven; composer install"
 
-      - name: Run Koseven Unittest(s)
+      - name: Run Koseven Unittest(s) PHP 8.3
         run: docker exec unittest /bin/sh -c "cd /tmp/koseven; php vendor/bin/phpunit"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ on: [push,pull_request]
 
 jobs:
   test:
-    runs-on: 
-      labels: [self-hosted, k3s]
+    runs-on:   ubuntu-latest
     steps:
       - uses: actions/checkout@v1
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ composer.lock
 /build/logs/
 /memory
 /.phpunit.cache/code-coverage/
+/.env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ All features and bugfixes must be fully tested and must have a reference to an i
 It's highly recommended that you write/run unit tests during development as it can help you pick up on issues early on.  See the Unit Testing section below.
 
 ## Cloning repo
-Go to https://github.com/koseven/koseven for each repo in the top right theres a button that says Fork. Click there to clone each repo. That will copy the repos to your github user, ex: https://github.com/neo22s/koseven
+Go to https://github.com/koseven/koseven for each repo in the top right theres a button that says Fork. Click there to clone each repo. That will copy the repos to your github user, ex: https://github.com/koseven/koseven
 
 Clone your project in local and use devel branch
 ```
-git clone git@github.com:neo22s/koseven.git
+git clone git@github.com:koseven/koseven.git
 cd koseven
 git checkout devel
 ```
@@ -37,7 +37,7 @@ git commit -a -m 'working closed etc  #725' # this will commit and mention an is
 ```
 
 ## Pull Requests
-Now you have new code at your fork ex https://github.com/neo22s/koseven. To move them to the original https://github.com/koseven/koseven repo you need to go to https://github.com/neo22s/koseven, and click on Pull Request (next to compare). This will create a pull request to the original code and the responsible will decide to merge it or not.
+Now you have new code at your fork ex https://github.com/koseven/koseven. To move them to the original https://github.com/koseven/koseven repo you need to go to https://github.com/koseven/koseven, and click on Pull Request (next to compare). This will create a pull request to the original code and the responsible will decide to merge it or not.
 
 Notes:
 - Try to submit pull requests against devel branch for easier merging

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License](https://poser.pugx.org/koseven/koseven/license.svg)](https://packagist.org/packages/koseven/koseven)
 [![Github Issues](https://img.shields.io/github/issues/koseven/koseven.svg)](https://github.com/koseven/koseven/issues)
 
+## [PHP 8.3 ready branch](https://github.com/koseven/koseven/tree/php8.3)
+
 ## [Download 3.3.9](https://github.com/koseven/koseven/releases/tag/3.3.9)
 
 Koseven is an elegant, open source, and object oriented HMVC framework built using PHP7, by a team of volunteers. It aims to be swift, secure, and small. It is based and nearly full compatible on defunct [Kohana](http://kohanaframework.org/) 3.3.X.
@@ -59,6 +61,32 @@ This will help us to fix the issue as quickly as possible, and if you'd like to 
 ## Contributing
 
 Any help is more than welcome! Please see [Contributing](CONTRIBUTING.md) for detailed Instructions.
+
+## Docker
+```
+cp .env.dist .env
+docker compose up -d
+docker compose exec koseven bash
+```
+
+#### Inside container
+```shell
+service redis-server start
+cd /var/www
+git config --global --add safe.directory /var/www
+composer self-update
+composer diagnose
+composer install
+```
+
+## Unittests
+```shell
+# For clear cache
+service redis-server restart
+vendor/bin/phpunit
+# Switch PHP version
+update-alternatives --config php
+```
 
 ## Special Thanks
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "issues": "https://github.com/koseven/koseven/issues"
   },
   "require": {
-    "php": ">=7.3",
+    "php": ">=8.3",
     "ext-dom": "*",
     "ext-json": "*",
     "ext-simplexml": "*",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  koseven:
+    env_file:
+      - .env
+    image: koseven/docker:travis-devel
+    container_name: ${COMPOSE_PROJECT_NAME}-php
+    hostname: ${COMPOSE_PROJECT_NAME}-php
+    restart: unless-stopped
+    volumes:
+      - .:/var/www/
+      - ./public:/var/www/public
+    networks:
+      - default
+    command: php -S localhost:8000

--- a/modules/cache/classes/KO7/Cache/Sqlite.php
+++ b/modules/cache/classes/KO7/Cache/Sqlite.php
@@ -42,7 +42,7 @@ class KO7_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageColl
 		$this->_db = new PDO('sqlite:'.$database);
 
 		// Test for existing DB
-		$result = $this->_db->query("SELECT * FROM sqlite_master WHERE name = 'caches' AND type = 'table'")->fetchAll();
+		$result = $this->_db->query(/** @lang SQLite */ "SELECT * FROM sqlite_master WHERE name = 'caches' AND type = 'table'")->fetchAll();
 
 		// If there is no table, create a new one
 		if (0 == count($result))
@@ -77,7 +77,7 @@ class KO7_Cache_Sqlite extends Cache implements Cache_Tagging, Cache_GarbageColl
 	public function get($id, $default = NULL)
 	{
 		// Prepare statement
-		$statement = $this->_db->prepare('SELECT id, expiration, cache FROM caches WHERE id = :id LIMIT 0, 1');
+		$statement = $this->_db->prepare(/** @lang SQLite */ 'SELECT id, expiration, cache FROM caches WHERE id = :id LIMIT 0, 1');
 
 		// Try and load the cache based on id
 		try

--- a/modules/cache/tests/cache/request/client/CacheTest.php
+++ b/modules/cache/tests/cache/request/client/CacheTest.php
@@ -106,14 +106,15 @@ class KO7_Request_Client_CacheTest extends Unittest_TestCase {
 
 		$key = $request->client()->cache()->create_cache_key($request);
 
-		$cache_mock->expects($this->at(0))
+		$cache_mock->expects($this->exactly(2))
 			->method('set')
-			->with($this->stringEndsWith($key), $this->identicalTo(0));
-
-		$cache_mock->expects($this->at(1))
-			->method('set')
-			->with($this->identicalTo($key), $this->anything(), $this->identicalTo($lifetime))
-			->will($this->returnValue(TRUE));
+			->withConsecutive(
+			// 1st call – we write an “empty” marker for 0 sec
+				[$this->stringEndsWith($key), $this->identicalTo(0)],
+				//2nd call – the cache itself with TTL
+				[$this->identicalTo($key), $this->anything(), $this->identicalTo($lifetime)]
+			)
+			->willReturnOnConsecutiveCalls(true, true);
 
 		$this->assertTrue(
 			$request->client()->cache()

--- a/modules/codebench/classes/Bench/ValidURL.php
+++ b/modules/codebench/classes/Bench/ValidURL.php
@@ -45,7 +45,7 @@ class Bench_ValidURL extends Codebench {
 
 	public function bench_filter_var($url)
 	{
-		return (bool) filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED);
+		return (bool) filter_var($url, FILTER_VALIDATE_URL, FILTER_VALIDATE_URL);
 	}
 
 	public function bench_regex($url)

--- a/modules/codebench/views/codebench.php
+++ b/modules/codebench/views/codebench.php
@@ -15,9 +15,11 @@
 <head>
 
 	<meta charset="utf-8" />
-	<title><?php if ($class !== ''): ?>
-			<?php echo $class, ' · ' ?>
-		<?php endif; ?>Codebench</title>
+	<title><?php if (!empty($class)) {
+			if ($class !== ''): ?>
+					<?php echo $class, ' · ' ?>
+				<?php endif;
+		} ?>Codebench</title>
 
 	<style>
 		/* General styles*/

--- a/modules/database/classes/KO7/Database/Query/Builder/Insert.php
+++ b/modules/database/classes/KO7/Database/Query/Builder/Insert.php
@@ -54,7 +54,7 @@ class KO7_Database_Query_Builder_Insert extends Database_Query_Builder {
 	public function table($table)
 	{
 		if ( ! is_string($table))
-			throw new KO7_Exception('INSERT INTO syntax does not allow table aliasing');
+			throw new KO7_Exception('--INSERT INTO syntax does not allow table aliasing');
 
 		$this->_table = $table;
 
@@ -85,7 +85,7 @@ class KO7_Database_Query_Builder_Insert extends Database_Query_Builder {
 	{
 		if ( ! is_array($this->_values))
 		{
-			throw new KO7_Exception('INSERT INTO ... SELECT statements cannot be combined with INSERT INTO ... VALUES');
+			throw new KO7_Exception('--INSERT INTO ... SELECT statements cannot be combined with INSERT INTO ... VALUES');
 		}
 
 		// Get all of the passed values

--- a/modules/kohana/views/kohana/error.php
+++ b/modules/kohana/views/kohana/error.php
@@ -47,42 +47,54 @@ $error_id = uniqid('error');
     }
 </script>
 <div id="kohana_error">
-    <h1><span class="type"><?php echo $class ?> [ <?php echo $code ?> ]:</span> <span class="message"><?php echo htmlspecialchars( (string) $message, ENT_QUOTES | ENT_IGNORE, KO7::$charset, TRUE); ?></span></h1>
+    <h1><span class="type"><?php if (!empty($class)) {
+				echo $class;
+			} ?> [ <?php if (!empty($code)) {
+				echo $code;
+			} ?> ]:</span> <span class="message"><?php if (!empty($message)) {
+				echo htmlspecialchars( (string) $message, ENT_QUOTES | ENT_IGNORE, KO7::$charset, TRUE);
+			} ?></span></h1>
     <div id="<?php echo $error_id ?>" class="content">
-        <p><span class="file"><?php echo Debug::path($file) ?> [ <?php echo $line ?> ]</span></p>
+        <p><span class="file"><?php if (!empty($file)) {
+					echo Debug::path($file);
+				} ?> [ <?php if (!empty($line)) {
+					echo $line;
+				} ?> ]</span></p>
         <?php echo Debug::source($file, $line) ?>
         <ol class="trace">
-            <?php foreach (Debug::trace($trace) as $i => $step): ?>
-                <li>
-                    <p>
-					<span class="file">
-						<?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
-                            <a href="#<?php echo $source_id ?>" onclick="return koggle('<?php echo $source_id ?>')"><?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]</a>
-                        <?php else: ?>
-                            {<?php echo I18n::get('PHP internal call') ?>}
-                        <?php endif ?>
-					</span>
-                        &raquo;
-                        <?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo I18n::get('arguments') ?></a><?php endif ?>)
-                    </p>
-                    <?php if (isset($args_id)): ?>
-                        <div id="<?php echo $args_id ?>" class="collapsed">
-                            <table cellspacing="0">
-                                <?php foreach ($step['args'] as $name => $arg): ?>
-                                    <tr>
-                                        <td><code><?php echo $name ?></code></td>
-                                        <td><pre><?php echo Debug::dump($arg) ?></pre></td>
-                                    </tr>
-                                <?php endforeach ?>
-                            </table>
-                        </div>
-                    <?php endif ?>
-                    <?php if (isset($source_id)): ?>
-                        <pre id="<?php echo $source_id ?>" class="source collapsed"><code><?php echo $step['source'] ?></code></pre>
-                    <?php endif ?>
-                </li>
-                <?php unset($args_id, $source_id); ?>
-            <?php endforeach ?>
+            <?php if (!empty($trace)) {
+				foreach (Debug::trace($trace) as $i => $step): ?>
+					<li>
+						<p>
+						<span class="file">
+							<?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
+								<a href="#<?php echo $source_id ?>" onclick="return koggle('<?php echo $source_id ?>')"><?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]</a>
+							<?php else: ?>
+								{<?php echo I18n::get('PHP internal call') ?>}
+							<?php endif ?>
+						</span>
+							&raquo;
+							<?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo I18n::get('arguments') ?></a><?php endif ?>)
+						</p>
+						<?php if (isset($args_id)): ?>
+							<div id="<?php echo $args_id ?>" class="collapsed">
+								<table cellspacing="0">
+									<?php foreach ($step['args'] as $name => $arg): ?>
+										<tr>
+											<td><code><?php echo $name ?></code></td>
+											<td><pre><?php echo Debug::dump($arg) ?></pre></td>
+										</tr>
+									<?php endforeach ?>
+								</table>
+							</div>
+						<?php endif ?>
+						<?php if (isset($source_id)): ?>
+							<pre id="<?php echo $source_id ?>" class="source collapsed"><code><?php echo $step['source'] ?></code></pre>
+						<?php endif ?>
+					</li>
+					<?php unset($args_id, $source_id); ?>
+				<?php endforeach;
+			} ?>
         </ol>
     </div>
     <h2><a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo I18n::get('Environment') ?></a></h2>

--- a/modules/minion/views/minion/error/validation.php
+++ b/modules/minion/views/minion/error/validation.php
@@ -1,10 +1,14 @@
 Parameter Errors:
-<?php foreach ($errors as $parameter => $error): ?>
-    <?php echo $parameter; ?> - <?php echo $error; ?> 
-<?php endforeach; ?>
+<?php if (!empty($errors)) {
+	foreach ($errors as $parameter => $error): ?>
+		<?php echo $parameter; ?> - <?php echo $error; ?>
+	<?php endforeach;
+} ?>
 
 Run
 
-    php index.php --task=<?php echo $task?> --help
+    php index.php --task=<?php if (!empty($task)) {
+	echo $task;
+} ?> --help
 
 for more help

--- a/modules/minion/views/minion/help/error.php
+++ b/modules/minion/views/minion/help/error.php
@@ -1,4 +1,6 @@
-<?php echo $error; ?>
+<?php if (!empty($error)) {
+	echo $error;
+} ?>
 
 Run 
 

--- a/modules/minion/views/minion/help/list.php
+++ b/modules/minion/views/minion/help/list.php
@@ -6,10 +6,12 @@ Usage
 
 Where {task} is one of the following:
 
-<?php foreach($tasks as $task): ?>
-  * <?php echo $task; ?>
+<?php if (!empty($tasks)) {
+	foreach($tasks as $task): ?>
+	  * <?php echo $task; ?>
 
-<?php endforeach; ?>
+	<?php endforeach;
+} ?>
 
 For more information on what a task does and usage details execute 
 

--- a/modules/minion/views/minion/help/task.php
+++ b/modules/minion/views/minion/help/task.php
@@ -1,17 +1,23 @@
 
 Usage
 =======
-php minion.php --task=<?php echo $task; ?> [--option1=value1] [--option2=value2]
+php minion.php --task=<?php if (!empty($task)) {
+	echo $task;
+} ?> [--option1=value1] [--option2=value2]
 
 Details
 =======
-<?php foreach($tags as $tag_name => $tag_content): ?>
-<?php echo ucfirst($tag_name) ?>: <?php echo $tag_content ?>
+<?php if (!empty($tags)) {
+	foreach($tags as $tag_name => $tag_content): ?>
+	<?php echo ucfirst($tag_name) ?>: <?php echo $tag_content ?>
 
-<?php endforeach; ?>
+	<?php endforeach;
+} ?>
 
 Description
 ===========
-<?php echo $description; ?>
+<?php if (!empty($description)) {
+	echo $description;
+} ?>
 
 

--- a/modules/pagination/views/pagination/basic.php
+++ b/modules/pagination/views/pagination/basic.php
@@ -1,37 +1,51 @@
 <p class="pagination">
 
-	<?php if ($first_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($first_page)) ?>" rel="first"><?php echo I18n::get('First') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('First') ?>
-	<?php endif ?>
-
-	<?php if ($previous_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($previous_page)) ?>" rel="prev"><?php echo I18n::get('Previous') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('Previous') ?>
-	<?php endif ?>
-
-	<?php for ($i = 1; $i <= $total_pages; $i++): ?>
-
-		<?php if ($i == $current_page): ?>
-			<strong><?php echo $i ?></strong>
+	<?php if (!empty($first_page)) {
+		if ($first_page !== FALSE): ?>
+			<a href="<?php if (!empty($page)) {
+				echo HTML::chars($page->url($first_page));
+			} ?>" rel="first"><?php echo I18n::get('First') ?></a>
 		<?php else: ?>
-			<a href="<?php echo HTML::chars($page->url($i)) ?>"><?php echo $i ?></a>
-		<?php endif ?>
+			<?php echo I18n::get('First') ?>
+		<?php endif;
+	} ?>
 
-	<?php endfor ?>
+	<?php if (!empty($previous_page)) {
+		if ($previous_page !== FALSE): ?>
+			<a href="<?php echo HTML::chars($page->url($previous_page)); ?>" rel="prev"><?php echo I18n::get('Previous') ?></a>
+		<?php else: ?>
+			<?php echo I18n::get('Previous') ?>
+		<?php endif;
+	} ?>
 
-	<?php if ($next_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo I18n::get('Next') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('Next') ?>
-	<?php endif ?>
+	<?php if (!empty($total_pages)) {
+		for ($i = 1; $i <= $total_pages; $i++): ?>
 
-	<?php if ($last_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo I18n::get('Last') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('Last') ?>
-	<?php endif ?>
+			<?php if (!empty($current_page)) {
+				if ($i == $current_page): ?>
+					<strong><?php echo $i ?></strong>
+				<?php else: ?>
+					<a href="<?php echo HTML::chars($page->url($i)); ?>"><?php echo $i ?></a>
+				<?php endif;
+			} ?>
+
+		<?php endfor;
+	} ?>
+
+	<?php if (!empty($next_page)) {
+		if ($next_page !== FALSE): ?>
+			<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo I18n::get('Next') ?></a>
+		<?php else: ?>
+			<?php echo I18n::get('Next') ?>
+		<?php endif;
+	} ?>
+
+	<?php if (!empty($last_page)) {
+		if ($last_page !== FALSE): ?>
+			<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo I18n::get('Last') ?></a>
+		<?php else: ?>
+			<?php echo I18n::get('Last') ?>
+		<?php endif;
+	} ?>
 
 </p><!-- .pagination -->

--- a/modules/pagination/views/pagination/floating.php
+++ b/modules/pagination/views/pagination/floating.php
@@ -10,14 +10,18 @@ $count_in = ( ! empty($config['count_in'])) ? (int) $config['count_in'] : 5;
 
 // Beginning group of pages: $n1...$n2
 $n1 = 1;
-$n2 = min($count_out, $total_pages);
+if (!empty($total_pages)) {
+	$n2 = min($count_out, $total_pages);
+}
 
 // Ending group of pages: $n7...$n8
 $n7 = max(1, $total_pages - $count_out + 1);
 $n8 = $total_pages;
 
 // Middle group of pages: $n4...$n5
-$n4 = max($n2 + 1, $current_page - $count_in);
+if (!empty($current_page)) {
+	$n4 = max($n2 + 1, $current_page - $count_in);
+}
 $n5 = min($n7 - 1, $current_page + $count_in);
 $use_middle = ($n5 >= $n4);
 
@@ -57,17 +61,23 @@ for ($i = $n7; $i <= $n8; ++$i)
 ?>
 <p class="pagination">
 
-	<?php if ($first_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($first_page)) ?>" rel="first"><?php echo I18n::get('First') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('First') ?>
-	<?php endif ?>
+	<?php if (!empty($first_page)) {
+		if ($first_page !== FALSE): ?>
+			<a href="<?php if (!empty($page)) {
+				echo HTML::chars($page->url($first_page));
+			} ?>" rel="first"><?php echo I18n::get('First') ?></a>
+		<?php else: ?>
+			<?php echo I18n::get('First') ?>
+		<?php endif;
+	} ?>
 
-	<?php if ($previous_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($previous_page)) ?>" rel="prev"><?php echo I18n::get('Previous') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('Previous') ?>
-	<?php endif ?>
+	<?php if (!empty($previous_page)) {
+		if ($previous_page !== FALSE): ?>
+			<a href="<?php echo HTML::chars($page->url($previous_page)) ?>" rel="prev"><?php echo I18n::get('Previous') ?></a>
+		<?php else: ?>
+			<?php echo I18n::get('Previous') ?>
+		<?php endif;
+	} ?>
 
 	<?php foreach ($links as $number => $content): ?>
 
@@ -79,16 +89,20 @@ for ($i = $n7; $i <= $n8; ++$i)
 
 	<?php endforeach ?>
 
-	<?php if ($next_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo I18n::get('Next') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('Next') ?>
-	<?php endif ?>
+	<?php if (!empty($next_page)) {
+		if ($next_page !== FALSE): ?>
+			<a href="<?php echo HTML::chars($page->url($next_page)) ?>" rel="next"><?php echo I18n::get('Next') ?></a>
+		<?php else: ?>
+			<?php echo I18n::get('Next') ?>
+		<?php endif;
+	} ?>
 
-	<?php if ($last_page !== FALSE): ?>
-		<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo I18n::get('Last') ?></a>
-	<?php else: ?>
-		<?php echo I18n::get('Last') ?>
-	<?php endif ?>
+	<?php if (!empty($last_page)) {
+		if ($last_page !== FALSE): ?>
+			<a href="<?php echo HTML::chars($page->url($last_page)) ?>" rel="last"><?php echo I18n::get('Last') ?></a>
+		<?php else: ?>
+			<?php echo I18n::get('Last') ?>
+		<?php endif;
+	} ?>
 
 </p><!-- .pagination -->

--- a/modules/userguide/classes/KO7/Controller/Userguide.php
+++ b/modules/userguide/classes/KO7/Controller/Userguide.php
@@ -160,7 +160,9 @@ abstract class KO7_Controller_Userguide extends Controller_Template {
 		$this->template->menu = Kodoc_Markdown::markdown($this->_get_all_menu_markdown());
 
 		// Bind the breadcrumb
-		$this->template->bind('breadcrumb', $breadcrumb);
+		if (!empty($breadcrumb)) {
+			$this->template->bind('breadcrumb', $breadcrumb);
+		}
 
 		// Bind the copyright
 		$this->template->copyright = KO7::$config->load('userguide.modules.'.$module.'.copyright');
@@ -229,7 +231,9 @@ abstract class KO7_Controller_Userguide extends Controller_Template {
 		$this->template->menu = Kodoc::menu();
 
 		// Bind the breadcrumb
-		$this->template->bind('breadcrumb', $breadcrumb);
+		if (!empty($breadcrumb)) {
+			$this->template->bind('breadcrumb', $breadcrumb);
+		}
 
 		// Add the breadcrumb
 		$breadcrumb = [];

--- a/modules/userguide/media/guide/css/screen.css
+++ b/modules/userguide/media/guide/css/screen.css
@@ -108,7 +108,6 @@ code, pre { color: #c33; } /* very optional, but still useful. W3C uses about th
 /* 24 COLUMN GRID */
 
 .container {width:950px;margin:0 auto;overflow:hidden;}
-.showgrid {background:url(../img/grid.png);}
 body {margin:1.5em 0;}
 div.span-1, div.span-2, div.span-3, div.span-4, div.span-5, div.span-6, div.span-7, div.span-8, div.span-9, div.span-10, div.span-11, div.span-12, div.span-13, div.span-14, div.span-15, div.span-16, div.span-17, div.span-18, div.span-19, div.span-20, div.span-21, div.span-22, div.span-23 {float:left;margin-right:10px;}
 div.span-24 {float:left;}

--- a/modules/userguide/media/guide/css/shThemeDefault.css
+++ b/modules/userguide/media/guide/css/shThemeDefault.css
@@ -100,7 +100,7 @@
 .syntaxhighlighter .script {
   font-weight: bold !important;
   color: #006699 !important;
-  background-color: none !important;
+  background-color: transparent !important;
 }
 .syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
   color: gray !important;

--- a/modules/userguide/views/userguide/api/class.php
+++ b/modules/userguide/views/userguide/api/class.php
@@ -1,7 +1,11 @@
 <h1>
-	<?php echo $doc->modifiers, $doc->class->name ?>
+	<?php if (!empty($doc)) {
+		echo $doc->modifiers, $doc->class->name;
+	} ?>
 	<?php foreach ($doc->parents as $parent): ?>
-	<br/><small>extends <?php echo HTML::anchor($route->uri(['class' => $parent->name]), $parent->name, NULL, NULL, TRUE) ?></small>
+	<br/><small>extends <?php if (!empty($route)) {
+				echo HTML::anchor($route->uri(['class' => $parent->name]), $parent->name, NULL, NULL, TRUE);
+			} ?></small>
 	<?php endforeach; ?>
 </h1>
 

--- a/modules/userguide/views/userguide/api/menu.php
+++ b/modules/userguide/views/userguide/api/menu.php
@@ -1,7 +1,8 @@
 
 <h2>Modules</h2>
 <ol class="menu">
-<?php foreach ($menu as $package => $categories): ksort($categories); ?>
+<?php if (!empty($menu)){
+foreach ($menu as $package => $categories): ksort($categories); ?>
 <li><span><strong><?php echo $package ?></strong></span>
 	<ol>
 	<?php foreach ($categories as $category => $classes): sort($classes); ?>
@@ -14,5 +15,6 @@
 		</li>
 	<?php endforeach ?>
 	</ol>
-<?php endforeach ?>
+<?php endforeach;
+} ?>
 </ol>

--- a/modules/userguide/views/userguide/api/method.php
+++ b/modules/userguide/views/userguide/api/method.php
@@ -1,9 +1,13 @@
 <div class="method">
 
-<?php $declares = $doc->method->getDeclaringClass(); ?>
+<?php if (!empty($doc)) {
+	$declares = $doc->method->getDeclaringClass();
+} ?>
 <h3 id="<?php echo $doc->method->name ?>">
 	<?php echo $doc->modifiers, $doc->method->name ?>( <?php echo $doc->params ? $doc->params_short() : '' ?>)
-	<small>(defined in <?php echo html::anchor($route->uri(['class' => $declares->name]), $declares->name, NULL, NULL, TRUE) ?>)</small>
+	<small>(defined in <?php if (!empty($route)) {
+			echo html::anchor($route->uri(['class' => $declares->name]), $declares->name, NULL, NULL, TRUE);
+		} ?>)</small>
 </h3>
 
 <div class="description">

--- a/modules/userguide/views/userguide/api/tags.php
+++ b/modules/userguide/views/userguide/api/tags.php
@@ -1,6 +1,8 @@
 <h4>Tags</h4>
 <ul class="tags">
-<?php foreach ($tags as $name => $set): ?>
+<?php if (!empty($tags)){
+foreach ($tags as $name => $set): ?>
 <li><?php echo ucfirst($name).($set?' - '.implode(', ',$set):''); ?>
-<?php endforeach ?>
+<?php endforeach;
+	} ?>
 </ul>

--- a/modules/userguide/views/userguide/api/toc.php
+++ b/modules/userguide/views/userguide/api/toc.php
@@ -55,15 +55,19 @@
 
 <div class="class-list">
 
-	<?php foreach ($classes as $class => $methods): $link = $route->uri(['class' => $class]) ?>
-	<div class="class <?php echo Text::alternate('left', 'right') ?>">
-		<h2><?php echo HTML::anchor($link, $class, NULL, NULL, TRUE) ?></h2>
-		<ul class="methods">
-		<?php foreach ($methods as $method): ?>
-			<li><?php echo HTML::anchor("{$link}#{$method}", "{$class}::{$method}", NULL, NULL, TRUE) ?></li>
-		<?php endforeach ?>
-		</ul>
-	</div>
-	<?php endforeach ?>
+	<?php if (!empty($classes)) {
+		foreach ($classes as $class => $methods): if (!empty($route)) {
+			$link = $route->uri(['class' => $class]);
+		} ?>
+		<div class="class <?php echo Text::alternate('left', 'right') ?>">
+			<h2><?php echo HTML::anchor($link, $class, NULL, NULL, TRUE) ?></h2>
+			<ul class="methods">
+			<?php foreach ($methods as $method): ?>
+				<li><?php echo HTML::anchor("{$link}#{$method}", "{$class}::{$method}", NULL, NULL, TRUE) ?></li>
+			<?php endforeach ?>
+			</ul>
+		</div>
+		<?php endforeach;
+	} ?>
 
 </div>

--- a/modules/userguide/views/userguide/error.php
+++ b/modules/userguide/views/userguide/error.php
@@ -1,3 +1,5 @@
 <h1>Kodoc - <?php echo 'Error'; ?></h1>
 
-<p><?php echo $message ?></p>
+<p><?php if (!empty($message)) {
+		echo $message;
+	} ?></p>

--- a/modules/userguide/views/userguide/examples/error.php
+++ b/modules/userguide/views/userguide/examples/error.php
@@ -1,6 +1,8 @@
 <?php
 
 // Should trigger an ErrorException with an E_NOTICE level
-echo $var_does_not_exist;
+if (!empty($var_does_not_exist)) {
+	echo $var_does_not_exist;
+}
 
 ?>

--- a/modules/userguide/views/userguide/page-toc.php
+++ b/modules/userguide/views/userguide/page-toc.php
@@ -1,10 +1,12 @@
-<?php if (is_array($array)): ?>
-<div class="page-toc">
-	<?php foreach ($array as $item): ?>
-		<?php if ($item['level'] > 1): ?>
-		<?php echo str_repeat('&nbsp;', ($item['level'] - 1) * 4) ?>
-		<?php endif ?>
-		<?php echo HTML::anchor('#'.$item['id'],$item['name'], NULL, NULL, TRUE); ?><br />
-	<?php endforeach; ?>
-</div>
-<?php endif ?>
+<?php if (!empty($array)) {
+	if (is_array($array)): ?>
+	<div class="page-toc">
+		<?php foreach ($array as $item): ?>
+			<?php if ($item['level'] > 1): ?>
+			<?php echo str_repeat('&nbsp;', ($item['level'] - 1) * 4) ?>
+			<?php endif ?>
+			<?php echo HTML::anchor('#'.$item['id'],$item['name'], NULL, NULL, TRUE); ?><br />
+		<?php endforeach; ?>
+	</div>
+	<?php endif;
+} ?>

--- a/modules/userguide/views/userguide/template.php
+++ b/modules/userguide/views/userguide/template.php
@@ -3,11 +3,17 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-<title><?php echo $title ?> | Koseven <?php echo 'User Guide'; ?></title>
+<title><?php if (!empty($title)) {
+		echo $title;
+	} ?> | Koseven <?php echo 'User Guide'; ?></title>
 
-<?php foreach ($styles as $style => $media) echo HTML::style($style, ['media' => $media], NULL, TRUE), "\n" ?>
+<?php if (!empty($styles)) {
+	foreach ($styles as $style => $media) echo HTML::style($style, ['media' => $media], NULL, TRUE), "\n";
+} ?>
 
-<?php foreach ($scripts as $script) echo HTML::script($script, NULL, NULL, TRUE), "\n" ?>
+<?php if (!empty($scripts)) {
+	foreach ($scripts as $script) echo HTML::script($script, NULL, NULL, TRUE), "\n";
+} ?>
 
 </head>
 <body>
@@ -33,40 +39,48 @@
 	<div id="kodoc-content">
 		<div class="wrapper">
 			<div class="container">
-				<?php if (count($breadcrumb) > 1): ?>
-				<div class="span-22 prefix-1 suffix-1">
-					<ul id="kodoc-breadcrumb">
-						<?php foreach ($breadcrumb as $link => $title): ?>
-							<?php if (is_string($link)): ?>
-							<li><?php echo HTML::anchor($link, $title, NULL, NULL, TRUE) ?></li>
-							<?php else: ?>
-							<li class="last"><?php echo $title ?></li>
-							<?php endif ?>
-						<?php endforeach ?>
-					</ul>
-				</div>
-				<?php endif ?>
+				<?php if (!empty($breadcrumb)) {
+					if (count($breadcrumb) > 1): ?>
+					<div class="span-22 prefix-1 suffix-1">
+						<ul id="kodoc-breadcrumb">
+							<?php foreach ($breadcrumb as $link => $title): ?>
+								<?php if (is_string($link)): ?>
+								<li><?php echo HTML::anchor($link, $title, NULL, NULL, TRUE) ?></li>
+								<?php else: ?>
+								<li class="last"><?php echo $title ?></li>
+								<?php endif ?>
+							<?php endforeach ?>
+						</ul>
+					</div>
+					<?php endif;
+				} ?>
 				<div class="span-6 prefix-1">
 					<div id="kodoc-topics">
-						<?php echo $menu ?>
+						<?php if (!empty($menu)) {
+							echo $menu;
+						} ?>
 					</div>
 				</div>
 				<div id="kodoc-body" class="span-16 suffix-1 last">
-					<?php echo $content ?>
+					<?php if (!empty($content)) {
+						echo $content;
+					} ?>
 
-					<?php if ($show_comments): ?>
-					<div id="disqus_thread" class="clear"></div>
-					<script type="text/javascript">
-						var disqus_identifier = '<?php echo HTML::chars(Request::current()->uri()) ?>';
-						(function() {
-							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://koseven.disqus.com/embed.js';
-							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-							})();
-					</script>
-					<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript=koseven">comments powered by Disqus.</a></noscript>
-					<a href="http://disqus.com" class="dsq-brlink">Documentation comments powered by <span class="logo-disqus">Disqus</span></a>
-					<?php endif ?>
+					<?php if (!empty($show_comments)) {
+						if ($show_comments): ?>
+						<div id="disqus_thread" class="clear"></div>
+						<script type="text/javascript">
+							var disqus_identifier = '<?php echo HTML::chars(Request::current()->uri()) ?>';
+							(function() {
+								var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+								dsq.src = 'http://koseven.disqus.com/embed.js';
+								(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+								})();
+						</script>
+						<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript=koseven">comments powered by Disqus.</a></noscript>
+						<a href="http://disqus.com" class="dsq-brlink">Documentation comments powered by <span class="logo-disqus">Disqus</span></a>
+						<?php endif;
+					} ?>
 				</div>
 			</div>
 		</div>
@@ -88,20 +102,7 @@
 	</div>
 
 <?php if (KO7::$environment === KO7::PRODUCTION): ?>
-<script type="text/javascript">
-//<![CDATA[
-(function() {
-	var links = document.getElementsByTagName('a');
-	var query = '?';
-	for(var i = 0; i < links.length; i++) {
-	if(links[i].href.indexOf('#disqus_thread') >= 0) {
-		query += 'url' + i + '=' + encodeURIComponent(links[i].href) + '&';
-	}
-	}
-	document.write('<script charset="utf-8" type="text/javascript" src="http://disqus.com/forums/koseven/get_num_replies.js' + query + '"></' + 'script>');
-})();
-//]]>
-</script>
+    <a class="btn btn-secondary" href="https://telegram.me/koseven" aria-label="koseven Telegram Group" target="_blank"><svg class="svg-inline--fa fa-telegram fa-w-16" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="telegram" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512" data-fa-i2svg=""><path fill="currentColor" d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm121.8 169.9l-40.7 191.8c-3 13.6-11.1 16.9-22.4 10.5l-62-45.7-29.9 28.8c-3.3 3.3-6.1 6.1-12.5 6.1l4.4-63.1 114.9-103.8c5-4.4-1.1-6.9-7.7-2.5l-142 89.4-61.2-19.1c-13.3-4.2-13.6-13.3 2.8-19.7l239.1-92.2c11.1-4 20.8 2.7 17.2 19.5z"></path></svg><!-- <i class="fab fa-telegram"></i> --> Telegram</a>
 <?php endif ?>
 </body>
 </html>

--- a/public/install.php
+++ b/public/install.php
@@ -231,7 +231,7 @@
                 <?php if (extension_loaded('mbstring')): ?>
                 <tr>
                     <th>Mbstring Not Overloaded</th>
-                    <?php if (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING): $failed = TRUE ?>
+                    <?php if (ini_get('mbstring.func_overload')): $failed = TRUE ?>
                     <td class="fail">The <a href="http://php.net/mbstring">mbstring</a> extension is overloading PHP's native string functions.</td>
                     <?php else: ?>
                     <td class="pass">Pass</td>

--- a/system/classes/KO7/HTTP/Header.php
+++ b/system/classes/KO7/HTTP/Header.php
@@ -35,7 +35,7 @@ class KO7_HTTP_Header extends ArrayObject {
 		{
 			$value = trim(str_replace(["\r", "\n"], '', $parts[$key]));
 
-			$pattern = '~\b(\;\s*+)?q\s*+=\s*+([.0-9]+)~';
+			$pattern = '~\b(;\s*+)?q\s*+=\s*+([.0-9]+)~';
 
 			// If there is no quality directive, return default
 			if ( ! preg_match($pattern, $value, $quality))
@@ -345,17 +345,17 @@ class KO7_HTTP_Header extends ArrayObject {
 	 * @param   mixed   $index      index to set `$newval` to
 	 * @param   mixed   $newval     new value to set
 	 * @param   boolean $replace    replace existing value
-	 * @return  void
+	 * @return  ?mixed
 	 * @since   3.2.0
 	 */
-	public function offsetSet(mixed $index, mixed $newval, bool $replace = TRUE): void
+	public function offsetSet(mixed $index, mixed $newval, bool $replace = TRUE)
 	{
 		// Ensure the index is lowercase
 		$index = strtolower($index);
 
 		if ($replace OR ! $this->offsetExists($index))
 		{
-			parent::offsetSet($index, $newval);
+			return parent::offsetSet($index, $newval);
 		}
 
 		$current_value = $this->offsetGet($index);

--- a/system/tests/ko7/TextTest.php
+++ b/system/tests/ko7/TextTest.php
@@ -315,7 +315,7 @@ class KO7_TextTest extends Unittest_TestCase
 			break;
 		}
 
-		$this->assertRegExp('/^['.$pool.']{'.$length.'}$/u', Text::random($type, $length));
+		$this->assertMatchesRegularExpression('/^['.$pool.']{'.$length.'}$/u', Text::random($type, $length));
 	}
 
 	/**

--- a/system/views/ko7/error.php
+++ b/system/views/ko7/error.php
@@ -52,61 +52,73 @@ $error_id = uniqid('error', false);
         <div id="koseven_error">
             <h1>
                 <span class="type">
-                    <?php echo $class ?> [ <?php echo $code ?> ]:
+                    <?php if (!empty($class)) {
+						echo $class;
+					} ?> [ <?php if (!empty($code)) {
+						echo $code;
+					} ?> ]:
                 </span>
                 <span class="message">
-                    <?php echo htmlspecialchars( (string) $message, ENT_QUOTES | ENT_IGNORE, KO7::$charset, TRUE); ?>
+                    <?php if (!empty($message)) {
+						echo htmlspecialchars( (string) $message, ENT_QUOTES | ENT_IGNORE, KO7::$charset, TRUE);
+					} ?>
                 </span>
             </h1>
-            <div id="<?php echo $error_id ?>" class="content">
+            <div id="<?php echo $error_id; ?>" class="content">
                 <p>
                     <span class="file">
-                        <?php echo Debug::path($file) ?> [ <?php echo $line ?> ]
+                        <?php if (!empty($file)) {
+							echo Debug::path($file);
+						} ?> [ <?php if (!empty($line)) {
+							echo $line;
+						} ?> ]
                     </span>
                 </p>
                 <?php echo Debug::source($file, $line) ?>
                 <ol class="trace">
-                <?php foreach (Debug::trace($trace) as $i => $step): ?>
-                    <li>
-                        <p>
-                            <span class="file">
-                                <?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
-                                    <a href="#<?php echo $source_id ?>" onclick="return toggle('<?php echo $source_id ?>')">
-                                        <?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]
-                                    </a>
-                                <?php else: ?>
-                                    {<?php echo I18n::get('PHP internal call') ?>}
-                                <?php endif ?>
-                            </span>
-                            &raquo;
-                            <?php echo $step['function'] ?>(
-                                <?php if ($step['args']): $args_id = $error_id.'args'.$i; ?>
-                                    <a href="#<?php echo $args_id ?>" onclick="return toggle('<?php echo $args_id ?>')">
-                                        <?php echo I18n::get('arguments') ?>
-                                    </a>
-                                <?php endif ?>
-                            )
-                        </p>
-                        <?php if (isset($args_id)): ?>
-                            <div id="<?php echo $args_id ?>" class="collapsed">
-                                <table cellspacing="0">
-                                <?php foreach ($step['args'] as $name => $arg): ?>
-                                    <tr>
-                                        <td><code><?php echo $name ?></code></td>
-                                        <td><pre><?php echo Debug::dump($arg) ?></pre></td>
-                                    </tr>
-                                <?php endforeach ?>
-                                </table>
-                            </div>
-                        <?php endif ?>
-                        <?php if (isset($source_id)): ?>
-                            <pre id="<?php echo $source_id ?>" class="source collapsed">
-                                <code><?php echo $step['source'] ?></code>
-                            </pre>
-                        <?php endif ?>
-                    </li>
-                    <?php unset($args_id, $source_id); ?>
-                <?php endforeach ?>
+                <?php if (!empty($trace)) {
+					foreach (Debug::trace($trace) as $i => $step): ?>
+						<li>
+							<p>
+								<span class="file">
+									<?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
+										<a href="#<?php echo $source_id ?>" onclick="return toggle('<?php echo $source_id ?>')">
+											<?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]
+										</a>
+									<?php else: ?>
+										{<?php echo I18n::get('PHP internal call') ?>}
+									<?php endif ?>
+								</span>
+								&raquo;
+								<?php echo $step['function'] ?>(
+									<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?>
+										<a href="#<?php echo $args_id ?>" onclick="return toggle('<?php echo $args_id ?>')">
+											<?php echo I18n::get('arguments') ?>
+										</a>
+									<?php endif ?>
+								)
+							</p>
+							<?php if (isset($args_id)): ?>
+								<div id="<?php echo $args_id ?>" class="collapsed">
+									<table cellspacing="0">
+									<?php foreach ($step['args'] as $name => $arg): ?>
+										<tr>
+											<td><code><?php echo $name ?></code></td>
+											<td><pre><?php echo Debug::dump($arg) ?></pre></td>
+										</tr>
+									<?php endforeach ?>
+									</table>
+								</div>
+							<?php endif ?>
+							<?php if (isset($source_id)): ?>
+								<pre id="<?php echo $source_id ?>" class="source collapsed">
+									<code><?php echo $step['source'] ?></code>
+								</pre>
+							<?php endif ?>
+						</li>
+						<?php unset($args_id, $source_id); ?>
+					<?php endforeach;
+				} ?>
                 </ol>
             </div>
             <h2>


### PR DESCRIPTION
# PR Details

Fix unittest, move to PHP >=8.3

### Description

Fix unittest, move to PHP >=8.3
- Add Docker file, update README.md
- Fix all errors in PHPStorm Inspect Code

### Related Issue

#471 

### Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
