### PR TITLE
Fix for HTTP::redirect() goes to "url, url" not "url"

### DIFF
--- a/system/classes/KO7/HTTP/Header.php
+++ b/system/classes/KO7/HTTP/Header.php
@@ -356,6 +356,7 @@ class KO7_HTTP_Header extends ArrayObject {
 		if ($replace OR ! $this->offsetExists($index))
 		{
 			parent::offsetSet($index, $newval);
+			return;
 		}
 
 		$current_value = $this->offsetGet($index);


### PR DESCRIPTION
Implementing resolution from @silasautomation for https://github.com/koseven/koseven/issues/533

# PR Details

Returns redirect url instead of runnning twice.

### Description

Exit as soon as redirect has been implements.

### Related Issue

[Issue 533](https://github.com/koseven/koseven/issues/533)

### How Has This Been Tested

Shown to be working in tests

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
